### PR TITLE
Add openssl for nix build

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -13,4 +13,4 @@ extra-deps:
 flags: {}
 extra-package-dbs: []
 nix:
-  packages: [gmp]
+  packages: [gmp, openssl]


### PR DESCRIPTION
Resolves `* Missing C library: crypto` on nix-based stack builds.