### PR TITLE
Add `id` function to the demo program.

### DIFF
--- a/src/Demo.pls
+++ b/src/Demo.pls
@@ -42,6 +42,10 @@ doit : (forall a. a -> a) -> Int -> Int {
   doit f x = f x
 }
 
+id : forall a. a -> a {
+  id x = x
+}
+
 {-
 localTest : Nat -> Nat {
   localTest x =


### PR DESCRIPTION
The README suggests trying an expression which relies on `id`, but it
is missing.