### PR TITLE
Bug fixes for type synthesis

### DIFF
--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -13,7 +13,7 @@ description:
 category: Language
 build-type: Simple
 extra-source-files:
-    cabal.project.local
+    cabal.project
 extra-doc-files: README.md
 
 source-repository head

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -116,14 +116,17 @@ kindOf (TyApp x ty (ty' :| [])) = do
 kindOf (TyApp x ty (ty' :| tys)) =
     kindOf (TyApp x (TyApp x ty (ty' :| [])) (NE.fromList tys))
 
+intApp :: Type a () -> Natural -> Type a ()
+intApp ty n = TyApp () ty (TyInt () n :| [])
+
 integerType :: Natural -> Type a ()
-integerType n = TyApp () (TyBuiltin () TyInteger) (TyInt () n :| [])
+integerType = intApp (TyBuiltin () TyInteger)
 
 bsType :: Natural -> Type a ()
-bsType n = TyApp () (TyBuiltin () TyByteString) (TyInt () n :| [])
+bsType = intApp (TyBuiltin () TyByteString)
 
 sizeType :: Natural -> Type a ()
-sizeType n = TyApp () (TyBuiltin () TySize) (TyInt () n :| [])
+sizeType = intApp (TyBuiltin () TySize)
 
 dummyUnique :: Unique
 dummyUnique = Unique 0

--- a/language-plutus-core/test/Spec.hs
+++ b/language-plutus-core/test/Spec.hs
@@ -8,6 +8,7 @@ import           Data.Foldable                         (fold)
 import           Data.Function                         (on)
 import qualified Data.IntMap                           as IM
 import qualified Data.List.NonEmpty                    as NE
+import           Data.Maybe                            (fromMaybe)
 import qualified Data.Text                             as T
 import           Data.Text.Encoding                    (encodeUtf8)
 import           Data.Text.Prettyprint.Doc             hiding (annotate)
@@ -175,7 +176,7 @@ withTypes = collectErrors . fmap (fmap showType . annotateST) . parseScoped
 
 showType :: Pretty a => (TypeState a, Program TyNameWithKind NameWithType a) -> T.Text
 showType (TypeState _ tys, Program _ _ t) = either printError (T.pack . show) $ runTypeCheckM i $ typeOf t
-    where i = fst $ IM.findMax tys
+    where i = fromMaybe 0 (fst <$> IM.lookupMax tys)
 
 asGolden :: Pretty a => TestFunction a -> TestName -> TestTree
 asGolden f file = goldenVsString file (file ++ ".golden") (asIO f file)

--- a/language-plutus-core/test/types/addInteger.plc
+++ b/language-plutus-core/test/types/addInteger.plc
@@ -1,8 +1,8 @@
 (program 0.1.0
   [
-    (lam x t
-      [(con addInteger) x y]
+    (lam x [(con integer) (con 2)]
+      [(con addInteger) x (con 2 ! 1)]
     )
-    z
+    (con 2 ! 1)
   ]
 )

--- a/language-plutus-core/test/types/addInteger.plc
+++ b/language-plutus-core/test/types/addInteger.plc
@@ -1,8 +1,7 @@
 (program 0.1.0
   [
-    (lam x [(con integer) (con 2)]
-      [(con addInteger) x (con 2 ! 1)]
-    )
-    (con 2 ! 1)
+    (lam x t
+      [(con addInteger) x y])
+    z
   ]
 )

--- a/language-plutus-core/test/types/addIntegerCorrect.plc
+++ b/language-plutus-core/test/types/addIntegerCorrect.plc
@@ -1,7 +1,7 @@
 (program 0.1.0
   [
     (lam x [(con integer) (con 2)]
-      [{(con addInteger) (fun (fun [(con integer) (con 2)] [(con integer) (con 2)]) [(con integer) (con 2)])} x (con 2 ! 2)])
+      [{(con addInteger) (con 2)} x (con 2 ! 2)])
     (con 2 ! 2)
   ]
 )

--- a/language-plutus-core/test/types/addIntegerCorrect.plc
+++ b/language-plutus-core/test/types/addIntegerCorrect.plc
@@ -1,7 +1,7 @@
 (program 0.1.0
   [
     (lam x [(con integer) (con 2)]
-      [(con addInteger) x (con 2 ! 2)])
+      [{(con addInteger) (con 2)} x (con 2 ! 2)])
     (con 2 ! 2)
   ]
 )

--- a/language-plutus-core/test/types/addIntegerCorrect.plc
+++ b/language-plutus-core/test/types/addIntegerCorrect.plc
@@ -1,0 +1,7 @@
+(program 0.1.0
+  [
+    (lam x [(con integer) (con 2)]
+      [(con addInteger) x (con 2 ! 2)])
+    (con 2 ! 2)
+  ]
+)

--- a/language-plutus-core/test/types/addIntegerCorrect.plc
+++ b/language-plutus-core/test/types/addIntegerCorrect.plc
@@ -1,6 +1,7 @@
 (program 0.1.0
   [
     (lam x [(con integer) (con 2)]
+      {- FIXME instantiate this with the correct type -}
       [{(con addInteger) (con 2)} x (con 2 ! 2)])
     (con 2 ! 2)
   ]

--- a/language-plutus-core/test/types/addIntegerCorrect.plc
+++ b/language-plutus-core/test/types/addIntegerCorrect.plc
@@ -1,8 +1,7 @@
 (program 0.1.0
   [
     (lam x [(con integer) (con 2)]
-      {- FIXME instantiate this with the correct type -}
-      [{(con addInteger) (con 2)} x (con 2 ! 2)])
+      [{(con addInteger) (fun (fun [(con integer) (con 2)] [(con integer) (con 2)]) [(con integer) (con 2)])} x (con 2 ! 2)])
     (con 2 ! 2)
   ]
 )

--- a/language-plutus-core/test/types/addIntegerCorrect.plc.golden
+++ b/language-plutus-core/test/types/addIntegerCorrect.plc.golden
@@ -1,1 +1,1 @@
-Type mismatch at 4:7 in term '(con addInteger)'. Expected type '(fun * *)' , found type '(all  (size) (fun (con integer) (fun (con integer) (con integer))))'
+TyApp () (TyBuiltin () TyInteger) (TyInt () 2 :| [])

--- a/language-plutus-core/test/types/addIntegerCorrect.plc.golden
+++ b/language-plutus-core/test/types/addIntegerCorrect.plc.golden
@@ -1,0 +1,1 @@
+Type mismatch at 4:7 in term '(con addInteger)'. Expected type '(fun * *)' , found type '(all  (size) (fun (con integer) (fun (con integer) (con integer))))'


### PR DESCRIPTION
The allows us to express `(+2)` as a Plutus Core program, and fixes previously extant bugs with type application and term application.