### PR TITLE
language-plutus-core: add quasiquoter

### DIFF
--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -31,6 +31,7 @@ library
         Language.PlutusCore
         Language.PlutusCore.CkMachine
         Language.PlutusCore.Constant
+        Language.PlutusCore.TH
         Language.PlutusCore.Quote
         PlutusPrelude
     build-tools: alex -any, happy >=1.17.1
@@ -50,13 +51,15 @@ library
         Language.PlutusCore.Error
         Language.PlutusCore.TypeSynthesis
         Language.PlutusCore.Normalize
+        Language.PlutusCore.Subst
         Data.Functor.Foldable.Monadic
     default-language: Haskell2010
     other-extensions: DeriveGeneric DeriveAnyClass StandaloneDeriving
                       GeneralizedNewtypeDeriving TypeFamilies DeriveFunctor
                       DeriveFoldable DeriveTraversable FlexibleContexts OverloadedStrings
                       DerivingStrategies MonadComprehensions FlexibleInstances
-                      ConstrainedClassMethods TupleSections GADTs RankNTypes
+                      ConstrainedClassMethods TupleSections GADTs RankNTypes 
+                      DeriveLift TemplateHaskell QuasiQuotes
     ghc-options: -Wall -Wnoncanonical-monad-instances
                  -Wincomplete-uni-patterns -Wincomplete-record-updates
                  -Wredundant-constraints -Widentities
@@ -72,7 +75,9 @@ library
         text -any,
         prettyprinter -any,
         microlens -any,
-        composition-prelude -any
+        composition-prelude -any,
+        template-haskell -any,
+        th-lift-instances -any
 
     if (flag(development) && impl(ghc <8.4))
         ghc-options: -Werror
@@ -92,6 +97,7 @@ test-suite language-plutus-core-test
         Evaluation.Constant.SuccessFailure
         Evaluation.Constant.All
         Evaluation.Generator
+        Quotation.Spec
     default-language: Haskell2010
     other-extensions: OverloadedStrings
     ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall

--- a/language-plutus-core/prelude/PlutusPrelude.hs
+++ b/language-plutus-core/prelude/PlutusPrelude.hs
@@ -40,6 +40,8 @@ module PlutusPrelude ( -- * Reëxports from base
                      , parens
                      , squotes
                      , Doc
+                     , strToBs
+                     , bsToStr
                      ) where
 
 import           Control.Applicative                     (Alternative (..))
@@ -50,14 +52,16 @@ import           Control.Exception                       (Exception, throw)
 import           Control.Monad                           (guard, join)
 import           Data.Bifunctor                          (first, second)
 import           Data.Bool                               (bool)
+import qualified Data.ByteString.Lazy                    as BSL
 import           Data.Foldable                           (fold, toList)
-import           Data.Functor.Foldable                   (Recursive, Corecursive, embed, project, Base)
 import           Data.Function                           (on)
+import           Data.Functor.Foldable                   (Base, Corecursive, Recursive, embed, project)
 import           Data.List                               (foldl')
 import           Data.List.NonEmpty                      (NonEmpty (..))
 import           Data.Maybe                              (isJust)
 import           Data.Semigroup
 import qualified Data.Text                               as T
+import qualified Data.Text.Encoding                      as TE
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Render.String (renderString)
 import           Data.Text.Prettyprint.Doc.Render.Text   (renderStrict)
@@ -103,3 +107,10 @@ prettyString = renderString . layoutPretty defaultLayoutOptions . pretty
 -- | Like a version of 'everywhere' for recursion schemes. In an unreleased version thereof.
 hoist :: (Recursive t, Corecursive t) => (Base t t -> Base t t) -> t -> t
 hoist f = c where c = embed . f . fmap c . project
+
+strToBs :: String -> BSL.ByteString
+strToBs = BSL.fromStrict . TE.encodeUtf8 . T.pack
+
+bsToStr :: BSL.ByteString -> String
+bsToStr = T.unpack . TE.decodeUtf8 . BSL.toStrict
+

--- a/language-plutus-core/prelude/PlutusPrelude.hs
+++ b/language-plutus-core/prelude/PlutusPrelude.hs
@@ -34,6 +34,7 @@ module PlutusPrelude ( -- * Reëxports from base
                      , repeatM
                      , (?)
                      , Debug (..)
+                     , hoist
                      -- Reëxports from "Data.Text.Prettyprint.Doc"
                      , (<+>)
                      , parens
@@ -50,6 +51,7 @@ import           Control.Monad                           (guard, join)
 import           Data.Bifunctor                          (first, second)
 import           Data.Bool                               (bool)
 import           Data.Foldable                           (fold, toList)
+import           Data.Functor.Foldable                   (Recursive, Corecursive, embed, project, Base)
 import           Data.Function                           (on)
 import           Data.List                               (foldl')
 import           Data.List.NonEmpty                      (NonEmpty (..))
@@ -97,3 +99,7 @@ instance Functor f => Functor (PairT b f) where
 
 prettyString :: Pretty a => a -> String
 prettyString = renderString . layoutPretty defaultLayoutOptions . pretty
+
+-- | Like a version of 'everywhere' for recursion schemes. In an unreleased version thereof.
+hoist :: (Recursive t, Corecursive t) => (Base t t -> Base t t) -> t -> t
+hoist f = c where c = embed . f . fmap c . project

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -1,9 +1,15 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE LambdaCase #-}
+
 module Language.PlutusCore
     ( Configuration (..)
     , defaultCfg
     , debugCfg
       -- * Parser
     , parse
+    , parseST
+    , parseTermST
+    , parseTypeST
     , parseScoped
     -- * Pretty-printing
     , prettyText
@@ -37,6 +43,8 @@ module Language.PlutusCore
     , TypeState (..)
     , RenamedType
     , RenamedTerm
+    , discardAnnsTy
+    , discardAnnsTerm
     -- * Normalization
     , check
     , NormalizationError
@@ -74,6 +82,8 @@ import           Language.PlutusCore.TypeSynthesis
 import           PlutusPrelude
 import           Control.Monad.Except
 import           Control.Monad.State
+import           Data.Functor.Foldable
+
 
 newtype Configuration = Configuration Bool
 
@@ -115,3 +125,51 @@ formatDoc = fmap pretty . parse
 format :: Configuration -> BSL.ByteString -> Either ParseError T.Text
 format (Configuration True)  = fmap (render . debug) . parseScoped
 format (Configuration False) = fmap render . formatDoc
+
+discardAnnsName :: Name a -> Name ()
+discardAnnsName n = n { nameAttribute = () }
+
+discardAnnsTyName :: TyName a -> TyName ()
+discardAnnsTyName = TyName . discardAnnsName . unTyName
+
+discardAnnsKind :: Kind a -> Kind ()
+discardAnnsKind = cata f
+    where
+        f :: KindF a (Kind ()) -> Kind ()
+        f(TypeF _)     = Type ()
+        f(KindArrowF _ k k')        = KindArrow () k k'
+        f(SizeF _)     = Size ()
+
+discardAnnsTy :: forall a . Type TyName a -> Type TyName ()
+discardAnnsTy = cata f
+    where
+        f :: TypeF TyName a (Type TyName ()) -> Type TyName ()
+        f(TyAppF _ t t')     = TyApp () t t'
+        f(TyVarF _ n)        = TyVar () (discardAnnsTyName n)
+        f(TyFunF _ t t')     = TyFun () t t'
+        f(TyFixF _ n t)      = TyFix () (discardAnnsTyName n) t
+        f(TyForallF _ n k t) = TyForall () (discardAnnsTyName n) (discardAnnsKind k) t
+        f(TyBuiltinF _ n)    = TyBuiltin () n
+        f(TyIntF _ n)        = TyInt () n
+        f(TyLamF _ n k t)    = TyLam () (discardAnnsTyName n) (discardAnnsKind k) t
+
+discardAnnsTerm :: forall a . Term TyName Name a -> Term TyName Name ()
+discardAnnsTerm = cata f
+    where
+        f :: TermF TyName Name a (Term TyName Name ()) -> Term TyName Name ()
+        f(VarF _ n)         = Var () (discardAnnsName n)
+        f(TyAbsF _ n k t)   = TyAbs () (discardAnnsTyName n) (discardAnnsKind k) t
+        f(LamAbsF _ n ty t) = LamAbs () (discardAnnsName n) (discardAnnsTy ty) t
+        f(ApplyF _ t t')    = Apply () t t'
+        f(ConstantF _ c)    = Constant () (discardAnnsConstant c)
+        f(TyInstF _ t ty)   = TyInst () t (discardAnnsTy ty)
+        f(UnwrapF _ t)      = Unwrap () t
+        f(WrapF _ tn ty t)  = Wrap () (discardAnnsTyName tn) (discardAnnsTy ty) t
+        f(ErrorF _ ty)      = Error () (discardAnnsTy ty)
+
+discardAnnsConstant :: Constant a -> Constant ()
+discardAnnsConstant = \case
+    BuiltinInt _ n i -> BuiltinInt () n i
+    BuiltinBS _ n bs -> BuiltinBS () n bs
+    BuiltinSize _ n -> BuiltinSize () n
+    BuiltinName _ n -> BuiltinName () n

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Prelude.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Prelude.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
 
 module Language.PlutusCore.Constant.Prelude
     ( Size
@@ -14,6 +15,7 @@ import           Language.PlutusCore.Name
 import           Language.PlutusCore.Type
 import           PlutusPrelude
 import           Language.PlutusCore.Quote
+import           Language.PlutusCore.TH
 
 type Size = Natural
 type Value = Term
@@ -22,68 +24,39 @@ type Value = Term
 --
 -- > all (A :: *). A -> A
 getBuiltinUnit :: Quote (Type TyName ())
-getBuiltinUnit = do
-    a <- freshTyName () "A"
-    return
-        . TyForall () a (Type ())
-        . TyFun () (TyVar () a)
-        $ TyVar () a
+getBuiltinUnit = [plcType|(all a (type) (fun a a))|]
 
 -- | Church-encoded '()' as a PLC term.
 --
 -- > /\(A :: *) -> \(x : A) -> x
 getBuiltinUnitval :: Quote (Value TyName Name ())
-getBuiltinUnitval = do
-    a <- freshTyName () "A"
-    x <- freshName () "x"
-    return
-        . TyAbs () a (Type ())
-        . LamAbs () x (TyVar () a)
-        $ Var () x
+getBuiltinUnitval = [plcTerm|(abs a (type) (lam x a x))|]
 
 -- | Church-encoded '()' as a PLC type.
 --
 -- > all (A :: *). (() -> A) -> (() -> A) -> A
 getBuiltinBool :: Quote (Type TyName ())
-getBuiltinBool = do
-    a <- freshTyName () "A"
-    unit <- getBuiltinUnit
-    return
-        . TyForall () a (Type ())
-        . TyFun () (TyFun () unit (TyVar () a))
-        . TyFun () (TyFun () unit (TyVar () a))
-        $ TyVar () a
+getBuiltinBool = [plcType|(all a (type)
+                         (fun
+                         (fun getBuiltinUnit a)
+                         (fun
+                         (fun getBuiltinUnit a)
+                         a)))|]
 
 -- | Church-encoded 'True' as a PLC term.
 --
 -- > /\(A :: *) -> \(x y : () -> A) -> x ()
 getBuiltinTrue :: Quote (Value TyName Name ())
-getBuiltinTrue = do
-    builtinUnit <- getBuiltinUnit
-    builtinUnitval <- getBuiltinUnitval
-    a <- freshTyName () "A"
-    x <- freshName () "x"
-    y <- freshName () "y"
-    let unitFunA = TyFun () builtinUnit (TyVar () a)
-    return
-       . TyAbs () a (Type ())
-       . LamAbs () x unitFunA
-       . LamAbs () y unitFunA
-       $ Apply () (Var () x) builtinUnitval
+getBuiltinTrue = [plcTerm|(abs a (type)
+                         (lam x (fun getBuiltinUnit a)
+                         (lam y (fun getBuiltinUnit a)
+                         [x getBuiltinUnitval])))|]
 
 -- | Church-encoded 'False' as a PLC term.
 --
 -- > /\(A :: *) -> \(x y : () -> A) -> y ()
 getBuiltinFalse :: Quote (Value TyName Name ())
-getBuiltinFalse = do
-    builtinUnit <- getBuiltinUnit
-    builtinUnitval <- getBuiltinUnitval
-    a <- freshTyName () "A"
-    x <- freshName () "x"
-    y <- freshName () "y"
-    let unitFunA = TyFun () builtinUnit (TyVar () a)
-    return
-       . TyAbs () a (Type ())
-       . LamAbs () x unitFunA
-       . LamAbs () y unitFunA
-       $ Apply () (Var () y) builtinUnitval
+getBuiltinFalse = [plcTerm|(abs a (type)
+                         (lam x (fun getBuiltinUnit a)
+                         (lam y (fun getBuiltinUnit a)
+                         [y getBuiltinUnitval])))|]

--- a/language-plutus-core/src/Language/PlutusCore/Lexer.x
+++ b/language-plutus-core/src/Language/PlutusCore/Lexer.x
@@ -4,6 +4,7 @@
     {-# LANGUAGE DeriveGeneric         #-}
     {-# LANGUAGE OverloadedStrings     #-}
     {-# LANGUAGE StandaloneDeriving    #-}
+    {-# LANGUAGE DeriveLift            #-}
     {-# LANGUAGE ScopedTypeVariables   #-}
     {-# LANGUAGE FlexibleContexts      #-}
     {-# LANGUAGE FlexibleInstances     #-}
@@ -21,6 +22,7 @@
 import PlutusPrelude
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.Char8 as ASCII
+import Language.Haskell.TH.Syntax (Lift)
 import qualified Data.Text as T
 import Data.Text.Prettyprint.Doc.Internal (Doc (Text))
 import Language.PlutusCore.Lexer.Type
@@ -119,6 +121,7 @@ tokens :-
 
 deriving instance Generic AlexPosn
 deriving instance NFData AlexPosn
+deriving instance Lift AlexPosn
 
 instance Pretty (AlexPosn) where
     pretty (AlexPn _ line col) = pretty line <> ":" <> pretty col
@@ -217,7 +220,7 @@ alexEOF = EOF . alex_pos <$> get
 -- | An error encountered during parsing.
 data ParseError = LexErr String
                 | Unexpected (Token AlexPosn)
-                | Overflow AlexPosn Natural Integer 
+                | Overflow AlexPosn Natural Integer
                 deriving (Show, Eq, Generic, NFData)
 
 instance Pretty ParseError where

--- a/language-plutus-core/src/Language/PlutusCore/Lexer/Type.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Lexer/Type.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE DeriveAnyClass    #-}
-{-# LANGUAGE DeriveFunctor     #-}
-{-# LANGUAGE DeriveGeneric     #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveLift         #-}
+{-# LANGUAGE OverloadedStrings  #-}
 
 module Language.PlutusCore.Lexer.Type ( BuiltinName (..)
                                       , Version (..)
@@ -19,12 +20,13 @@ import           Data.Text.Prettyprint.Doc.Internal (Doc (Text))
 import           Language.PlutusCore.Name
 import           Numeric                            (showHex)
 import           PlutusPrelude
+import           Language.Haskell.TH.Syntax (Lift)
 
 -- | A builtin type
 data TypeBuiltin = TyByteString -- FIXME these should take integer/naturals
                  | TyInteger
                  | TySize
-                 deriving (Show, Eq, Ord, Generic, NFData)
+                 deriving (Show, Eq, Ord, Generic, NFData, Lift)
 
 -- | Builtin functions
 data BuiltinName = AddInteger
@@ -50,11 +52,11 @@ data BuiltinName = AddInteger
                  | TxHash
                  | BlockNum
                  | BlockTime
-                 deriving (Show, Eq, Ord, Generic, NFData)
+                 deriving (Show, Eq, Ord, Generic, NFData, Lift)
 
 -- | Version of Plutus Core to be used for the program.
 data Version a = Version a Natural Natural Natural
-               deriving (Show, Eq, Functor, Generic, NFData)
+               deriving (Show, Eq, Functor, Generic, NFData, Lift)
 
 -- | A keyword in Plutus Core.
 data Keyword = KwAbs

--- a/language-plutus-core/src/Language/PlutusCore/Parser.y
+++ b/language-plutus-core/src/Language/PlutusCore/Parser.y
@@ -4,6 +4,8 @@
     {-# LANGUAGE OverloadedStrings  #-}
     module Language.PlutusCore.Parser ( parse
                                       , parseST
+                                      , parseTermST
+                                      , parseTypeST
                                       , ParseError (..)
                                       ) where
 
@@ -21,7 +23,9 @@ import Language.PlutusCore.Name
 
 }
 
-%name parsePlutusCore
+%name parsePlutusCoreProgram Program
+%name parsePlutusCoreTerm Term
+%name parsePlutusCoreType Type
 %tokentype { Token AlexPosn }
 %error { parseError }
 %monad { Parse } { (>>=) } { pure }
@@ -146,7 +150,13 @@ handleInteger x sz i = if isOverflow
           k = 8 ^ sz `div` 2
 
 parseST :: BSL.ByteString -> StateT IdentifierState (Except ParseError) (Program TyName Name AlexPosn)
-parseST str =  runAlexST' str (runExceptT parsePlutusCore) >>= liftEither
+parseST str =  runAlexST' str (runExceptT parsePlutusCoreProgram) >>= liftEither
+
+parseTermST :: BSL.ByteString -> StateT IdentifierState (Except ParseError) (Term TyName Name AlexPosn)
+parseTermST str = runAlexST' str (runExceptT parsePlutusCoreTerm) >>= liftEither
+
+parseTypeST :: BSL.ByteString -> StateT IdentifierState (Except ParseError) (Type TyName AlexPosn)
+parseTypeST str = runAlexST' str (runExceptT parsePlutusCoreType) >>= liftEither
 
 -- | Parse a 'ByteString' containing a Plutus Core program, returning a 'ParseError' if syntactically invalid.
 --

--- a/language-plutus-core/src/Language/PlutusCore/Quote.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Quote.hs
@@ -6,10 +6,13 @@
 module Language.PlutusCore.Quote (
               runQuoteT
             , runQuote
+            , mapInner
             , freshUnique
             , freshName
             , freshTyName
-            , parse
+            , parseProgram
+            , parseTerm
+            , parseType
             , QuoteT
             , Quote
             ) where
@@ -19,7 +22,7 @@ import           Control.Monad.State
 import qualified Data.ByteString.Lazy       as BSL
 import           Language.PlutusCore.Lexer  (AlexPosn)
 import           Language.PlutusCore.Name
-import           Language.PlutusCore.Parser (ParseError, parseST)
+import           Language.PlutusCore.Parser (ParseError, parseST, parseTermST, parseTypeST)
 import           Language.PlutusCore.Type
 import           Data.Functor.Identity
 import           PlutusPrelude
@@ -68,11 +71,24 @@ freshName ann str = Name ann str <$> freshUnique
 freshTyName :: (Monad m) => a -> BSL.ByteString -> QuoteT m (TyName a)
 freshTyName = fmap TyName .* freshName
 
--- | Parse some PLC. The resulting program will have fresh names. The underlying monad must be capable
--- of handling any parse errors.
-parse :: (MonadError ParseError m) => BSL.ByteString -> QuoteT m (Program TyName Name AlexPosn)
+mapParseRun :: (MonadError ParseError m) => StateT IdentifierState (Except ParseError) a -> QuoteT m a
 -- we need to run the parser starting from our current next unique, then throw away the rest of the
 -- parser state and get back the new next unique
-parse str = mapInner (liftEither . runExcept) $ QuoteT $ StateT $ \nextU -> do
-    (p, (_, _, u)) <- runStateT (parseST str) (identifierStateFrom nextU)
+mapParseRun run = mapInner (liftEither . runExcept) $ QuoteT $ StateT $ \nextU -> do
+    (p, (_, _, u)) <- runStateT run (identifierStateFrom nextU)
     pure $ (p, u)
+
+-- | Parse a PLC program. The resulting program will have fresh names. The underlying monad must be capable
+-- of handling any parse errors.
+parseProgram :: (MonadError ParseError m) => BSL.ByteString -> QuoteT m (Program TyName Name AlexPosn)
+parseProgram str = mapParseRun (parseST str)
+
+-- | Parse a PLC term. The resulting program will have fresh names. The underlying monad must be capable
+-- of handling any parse errors.
+parseTerm :: (MonadError ParseError m) => BSL.ByteString -> QuoteT m (Term TyName Name AlexPosn)
+parseTerm str = mapParseRun (parseTermST str)
+
+-- | Parse a PLC type. The resulting program will have fresh names. The underlying monad must be capable
+-- of handling any parse errors.
+parseType :: (MonadError ParseError m) => BSL.ByteString -> QuoteT m (Type TyName AlexPosn)
+parseType str = mapParseRun (parseTypeST str)

--- a/language-plutus-core/src/Language/PlutusCore/Subst.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Subst.hs
@@ -1,101 +1,16 @@
 module Language.PlutusCore.Subst(
-                                  captureAvoidingSubstTerm
-                                , captureAvoidingSubstTy
-                                , substTerm
+                                  substTerm
                                 , substTy
                                 , fvTerm
                                 , ftvTerm
                                 , ftvTy
                                 ) where
 
-import           PlutusPrelude hiding (empty)
 import           Language.PlutusCore
+import           PlutusPrelude         hiding (empty)
 
-import           Control.Monad
 import           Data.Functor.Foldable
 import           Data.Set
-
-{--
-When we substitute in a term, we can't just splice in the AST, because it might have overlapping names.
-
-We resolve this by "upshifting" the unique counters of all the names in the term being substituted, so that
-they're guaranteed not to overlap with those in the term being substituted into.
---}
-
--- TODO: make nicer with lenses or something
-
-getNameUnique :: Name a -> Int
-getNameUnique = unUnique . nameUnique
-
-getTyNameUnique :: TyName a -> Int
-getTyNameUnique = getNameUnique . unTyName
-
-incNameUnique :: Int -> Name a -> Name a
-incNameUnique i n = n { nameUnique = (nameUnique n) { unUnique = ((getNameUnique n) + i) }}
-
-incTyNameUnique :: Int -> TyName a -> TyName a
-incTyNameUnique i n = n { unTyName = (incNameUnique i (unTyName n)) }
-
-incTermUniques :: Int -> Term TyName Name a -> Term TyName Name a
-incTermUniques i = mapNamesTerm (incTyNameUnique i) (incNameUnique i)
-
-incTypeUniques :: Int -> Type TyName a -> Type TyName a
-incTypeUniques i = mapNamesTy (incTyNameUnique i)
-
--- | Get the maximum unique in a term.
-maxUniqueTerm :: Term TyName Name a -> Int
-maxUniqueTerm = cata f
-  where
-    f(VarF _ n)         = getNameUnique n
-    f(TyAbsF _ n _ t)   = max (getTyNameUnique n) t
-    f(LamAbsF _ n ty t) = max (getNameUnique n) (max (maxUniqueTy ty) t)
-    f(ApplyF _ t1 t2)   = max t1 t2
-    f(TyInstF _ t ty)   = max t (maxUniqueTy ty)
-    f(UnwrapF _ t)      = t
-    f(WrapF _ n ty t)   = max (getTyNameUnique n) (max (maxUniqueTy ty) t)
-    f(ErrorF _ ty)      = maxUniqueTy ty
-    f(_)                = 0
-
--- | Get the maximum unique in a type.
-maxUniqueTy :: Type TyName a -> Int
-maxUniqueTy = cata f
-  where
-    f(TyVarF _ ty)          = getTyNameUnique ty
-    f(TyFunF _ i o)         = max i o
-    f(TyFixF _ bnd ty)      = max (getTyNameUnique bnd) ty
-    f(TyForallF _ bnd _ ty) = max (getTyNameUnique bnd) ty
-    f(TyLamF _ bnd _ ty)    = max (getTyNameUnique bnd) ty
-    f(TyAppF _ ty1 ty2)     = max ty1 ty2
-    f(_)                    = 0
-
--- | Apply the given functions to all the names in a term.
-mapNamesTerm ::
-  (tyname a -> tyname a) ->
-  (name a -> name a) ->
-  Term tyname name a ->
-  Term tyname name a
-mapNamesTerm tynameF nameF = hoist f
-  where
-    f(VarF a bnd)         = VarF a (nameF bnd)
-    f(TyAbsF a bnd k t)   = TyAbsF a (tynameF bnd) k t
-    f(LamAbsF a bnd ty t) = LamAbsF a (nameF bnd) (mapNamesTy tynameF ty) t
-    f(TyInstF a t ty)     = TyInstF a t (mapNamesTy tynameF ty)
-    f(WrapF a bnd ty t)   = WrapF a (tynameF bnd) (mapNamesTy tynameF ty) t
-    f(ErrorF a ty)        = ErrorF a (mapNamesTy tynameF ty)
-    f(x)                  = x
-
--- | Apply the given function to all the names in a type.
-mapNamesTy ::
-  (tyname a -> tyname a) ->
-  Type tyname a ->
-  Type tyname a
-mapNamesTy tynameF = hoist f
-  where
-    f(TyVarF a ty)          = TyVarF a (tynameF ty)
-    f(TyFixF a bnd ty)      = TyFixF a (tynameF bnd) ty
-    f(TyForallF a bnd k ty) = TyForallF a (tynameF bnd) k ty
-    f(TyLamF a bnd k ty)    = TyLamF a (tynameF bnd) k ty
-    f(x)                    = x
 
 -- | Naively substitute names using the given functions (i.e. do not account for scoping).
 substTerm ::
@@ -121,34 +36,10 @@ substTy ::
   Type tyname a
 substTy tynameF = hoist f
   where
-    f(TyVarF a ty)          = case tynameF ty of
+    f(TyVarF a ty) = case tynameF ty of
       Just t  -> project t
       Nothing -> TyVarF a ty
-    f(x)                    = x
-
--- | Safely substitute names using the given functions.
-captureAvoidingSubstTerm ::
-  (TyName a -> Maybe (Type TyName a)) ->
-  (Name a -> Maybe (Term TyName Name a)) ->
-  Term TyName Name a ->
-  Term TyName Name a
-captureAvoidingSubstTerm tynameF nameF t = let
-    maxUnique = maxUniqueTerm t
-    upscaleTerm = pure . (incTermUniques (maxUnique+1))
-    upscaleType = pure . (incTypeUniques (maxUnique+1))
-  in
-    substTerm (upscaleType <=< tynameF) (upscaleTerm <=< nameF) t
-
--- | Safely substitute names using the given function.
-captureAvoidingSubstTy ::
-  (TyName a -> Maybe (Type TyName a)) ->
-  Type TyName a ->
-  Type TyName a
-captureAvoidingSubstTy tynameF t = let
-    maxUnique = maxUniqueTy t
-    upscaleType = pure . (incTypeUniques (maxUnique+1))
-  in
-    substTy (upscaleType <=< tynameF) t
+    f(x)           = x
 
 -- Free variables
 

--- a/language-plutus-core/src/Language/PlutusCore/Subst.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Subst.hs
@@ -1,0 +1,190 @@
+module Language.PlutusCore.Subst(
+                                  captureAvoidingSubstTerm
+                                , captureAvoidingSubstTy
+                                , substTerm
+                                , substTy
+                                , fvTerm
+                                , ftvTerm
+                                , ftvTy
+                                ) where
+
+import           PlutusPrelude hiding (empty)
+import           Language.PlutusCore
+
+import           Control.Monad
+import           Data.Functor.Foldable
+import           Data.Set
+
+{--
+When we substitute in a term, we can't just splice in the AST, because it might have overlapping names.
+
+We resolve this by "upshifting" the unique counters of all the names in the term being substituted, so that
+they're guaranteed not to overlap with those in the term being substituted into.
+--}
+
+-- TODO: make nicer with lenses or something
+
+getNameUnique :: Name a -> Int
+getNameUnique = unUnique . nameUnique
+
+getTyNameUnique :: TyName a -> Int
+getTyNameUnique = getNameUnique . unTyName
+
+incNameUnique :: Int -> Name a -> Name a
+incNameUnique i n = n { nameUnique = (nameUnique n) { unUnique = ((getNameUnique n) + i) }}
+
+incTyNameUnique :: Int -> TyName a -> TyName a
+incTyNameUnique i n = n { unTyName = (incNameUnique i (unTyName n)) }
+
+incTermUniques :: Int -> Term TyName Name a -> Term TyName Name a
+incTermUniques i = mapNamesTerm (incTyNameUnique i) (incNameUnique i)
+
+incTypeUniques :: Int -> Type TyName a -> Type TyName a
+incTypeUniques i = mapNamesTy (incTyNameUnique i)
+
+-- | Get the maximum unique in a term.
+maxUniqueTerm :: Term TyName Name a -> Int
+maxUniqueTerm = cata f
+  where
+    f(VarF _ n)         = getNameUnique n
+    f(TyAbsF _ n _ t)   = max (getTyNameUnique n) t
+    f(LamAbsF _ n ty t) = max (getNameUnique n) (max (maxUniqueTy ty) t)
+    f(ApplyF _ t1 t2)   = max t1 t2
+    f(TyInstF _ t ty)   = max t (maxUniqueTy ty)
+    f(UnwrapF _ t)      = t
+    f(WrapF _ n ty t)   = max (getTyNameUnique n) (max (maxUniqueTy ty) t)
+    f(ErrorF _ ty)      = maxUniqueTy ty
+    f(_)                = 0
+
+-- | Get the maximum unique in a type.
+maxUniqueTy :: Type TyName a -> Int
+maxUniqueTy = cata f
+  where
+    f(TyVarF _ ty)          = getTyNameUnique ty
+    f(TyFunF _ i o)         = max i o
+    f(TyFixF _ bnd ty)      = max (getTyNameUnique bnd) ty
+    f(TyForallF _ bnd _ ty) = max (getTyNameUnique bnd) ty
+    f(TyLamF _ bnd _ ty)    = max (getTyNameUnique bnd) ty
+    f(TyAppF _ ty1 ty2)     = max ty1 ty2
+    f(_)                    = 0
+
+-- | Apply the given functions to all the names in a term.
+mapNamesTerm ::
+  (tyname a -> tyname a) ->
+  (name a -> name a) ->
+  Term tyname name a ->
+  Term tyname name a
+mapNamesTerm tynameF nameF = hoist f
+  where
+    f(VarF a bnd)         = VarF a (nameF bnd)
+    f(TyAbsF a bnd k t)   = TyAbsF a (tynameF bnd) k t
+    f(LamAbsF a bnd ty t) = LamAbsF a (nameF bnd) (mapNamesTy tynameF ty) t
+    f(TyInstF a t ty)     = TyInstF a t (mapNamesTy tynameF ty)
+    f(WrapF a bnd ty t)   = WrapF a (tynameF bnd) (mapNamesTy tynameF ty) t
+    f(ErrorF a ty)        = ErrorF a (mapNamesTy tynameF ty)
+    f(x)                  = x
+
+-- | Apply the given function to all the names in a type.
+mapNamesTy ::
+  (tyname a -> tyname a) ->
+  Type tyname a ->
+  Type tyname a
+mapNamesTy tynameF = hoist f
+  where
+    f(TyVarF a ty)          = TyVarF a (tynameF ty)
+    f(TyFixF a bnd ty)      = TyFixF a (tynameF bnd) ty
+    f(TyForallF a bnd k ty) = TyForallF a (tynameF bnd) k ty
+    f(TyLamF a bnd k ty)    = TyLamF a (tynameF bnd) k ty
+    f(x)                    = x
+
+-- | Naively substitute names using the given functions (i.e. do not account for scoping).
+substTerm ::
+  (tyname a -> Maybe (Type tyname a)) ->
+  (name a -> Maybe (Term tyname name a)) ->
+  Term tyname name a ->
+  Term tyname name a
+substTerm tynameF nameF = hoist f
+  where
+    f(VarF a bnd)         = case nameF bnd of
+      Just t  -> project t
+      Nothing -> VarF a bnd
+    f(LamAbsF a bnd ty t) = LamAbsF a bnd (substTy tynameF ty) t
+    f(TyInstF a t ty)     = TyInstF a t (substTy tynameF ty)
+    f(WrapF a bnd ty t)   = WrapF a bnd (substTy tynameF ty) t
+    f(ErrorF a ty)        = ErrorF a (substTy tynameF ty)
+    f(x)                  = x
+
+-- | Naively substitute names using the given function (i.e. do not account for scoping).
+substTy ::
+  (tyname a -> Maybe (Type tyname a)) ->
+  Type tyname a ->
+  Type tyname a
+substTy tynameF = hoist f
+  where
+    f(TyVarF a ty)          = case tynameF ty of
+      Just t  -> project t
+      Nothing -> TyVarF a ty
+    f(x)                    = x
+
+-- | Safely substitute names using the given functions.
+captureAvoidingSubstTerm ::
+  (TyName a -> Maybe (Type TyName a)) ->
+  (Name a -> Maybe (Term TyName Name a)) ->
+  Term TyName Name a ->
+  Term TyName Name a
+captureAvoidingSubstTerm tynameF nameF t = let
+    maxUnique = maxUniqueTerm t
+    upscaleTerm = pure . (incTermUniques (maxUnique+1))
+    upscaleType = pure . (incTypeUniques (maxUnique+1))
+  in
+    substTerm (upscaleType <=< tynameF) (upscaleTerm <=< nameF) t
+
+-- | Safely substitute names using the given function.
+captureAvoidingSubstTy ::
+  (TyName a -> Maybe (Type TyName a)) ->
+  Type TyName a ->
+  Type TyName a
+captureAvoidingSubstTy tynameF t = let
+    maxUnique = maxUniqueTy t
+    upscaleType = pure . (incTypeUniques (maxUnique+1))
+  in
+    substTy (upscaleType <=< tynameF) t
+
+-- Free variables
+
+-- | Get all the free term variables in a term.
+fvTerm :: (Ord (name a)) => Term tyname name a -> Set (name a)
+fvTerm = cata f
+  where
+    f(VarF _ n)        = singleton n
+    f(TyAbsF _ _ _ t)  = t
+    f(LamAbsF _ n _ t) = delete n t
+    f(ApplyF _ t1 t2)  = union t1 t2
+    f(TyInstF _ t _)   = t
+    f(UnwrapF _ t)     = t
+    f(WrapF _ _ _ t)   = t
+    f(_)               = empty
+
+-- | Get all the free type variables in a term.
+ftvTerm :: (Ord (tyname a)) => Term tyname name a -> Set (tyname a)
+ftvTerm = cata f
+  where
+    f(TyAbsF _ ty _ t)  = delete ty t
+    f(LamAbsF _ _ ty t) = union (ftvTy ty) t
+    f(ApplyF _ t1 t2)   = union t1 t2
+    f(TyInstF _ t ty)   = union t (ftvTy ty)
+    f(UnwrapF _ t)      = t
+    f(WrapF _ bnd ty t) = delete bnd (union (ftvTy ty) t)
+    f(_)                = empty
+
+-- | Get all the free type variables in a type.
+ftvTy :: (Ord (tyname a)) => Type tyname a -> Set (tyname a)
+ftvTy = cata f
+  where
+    f(TyVarF _ ty)          = singleton ty
+    f(TyFunF _ i o)         = union i o
+    f(TyFixF _ bnd ty)      = delete bnd ty
+    f(TyForallF _ bnd _ ty) = delete bnd ty
+    f(TyLamF _ bnd _ ty)    = delete bnd ty
+    f(TyAppF _ ty1 ty2)     = union ty1 ty2
+    f(_)                    = empty

--- a/language-plutus-core/src/Language/PlutusCore/TH.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TH.hs
@@ -1,0 +1,206 @@
+{-# LANGUAGE DeriveLift          #-}
+{-# LANGUAGE QuasiQuotes         #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Language.PlutusCore.TH (plcTerm, plcType, plcProgram) where
+
+import           Language.Haskell.TH hiding (Name, Type)
+import           Language.Haskell.TH.Quote
+
+import           Language.PlutusCore.Parser (ParseError)
+import           Language.PlutusCore.Quote
+import           Language.PlutusCore.Subst
+import           Language.PlutusCore.Name
+import           Language.PlutusCore.Type
+import           Language.PlutusCore (discardAnnsTerm, discardAnnsTy)
+
+import qualified Data.ByteString.Lazy       as BSL
+import qualified Data.Text                  as T
+import qualified Data.Text.Encoding         as TE
+
+import           Data.Set
+
+import qualified Data.Map                   as Map
+
+import           Control.Monad.Except
+import           Data.Functor.Identity
+
+{-
+This uses the approach in https://www.well-typed.com/blog/2014/10/quasi-quoting-dsls/ to use free
+object-level variables as metavariables. This also means you can only construct closed terms, which
+is what we want.
+-}
+
+strToBs :: String -> BSL.ByteString
+strToBs = BSL.fromStrict . TE.encodeUtf8 . T.pack
+
+bsToStr :: BSL.ByteString -> String
+bsToStr = T.unpack . TE.decodeUtf8 . BSL.toStrict
+
+{- Note [Metavar map functions]
+These functions are a little complicated: essentially, we need to reify the whole substitution map at
+compile time. Sadly, TH isn't clever enough to do this automatically, so we manually create
+the list of expressions, lift it to a quoted list, and then zip it back together with the
+automatically lifted list of source expressions.
+
+Also, although they're largely identical, we have two versions so we can put
+explicit type annotations in the generated code, which makes the type errors if you get
+things wrong much better.
+-}
+
+substs :: [BSL.ByteString] -> Q Exp
+substs fvsL = let substFun n = [| $(varE (mkName (bsToStr n)))|] in listE $ fmap substFun fvsL
+
+-- See note [Metavar map functions]
+-- | Get a quotation of a map between names and Haskell variable references to terms using the
+-- name as the variable name.
+metavarMapTerm :: Set (Name a) -> Q Exp
+metavarMapTerm ftvs = let ftvsL = fmap nameString $ toList $ ftvs in
+    [|
+        let
+            subs :: [Quote (Term TyName Name ())]
+            subs = $(substs ftvsL)
+            qm :: Quote (Map.Map (BSL.ByteString) (Term TyName Name ()))
+            qm = do
+                quoted <- sequence subs
+                pure $ Map.fromList $ zip ftvsL quoted
+        in qm
+    |]
+
+-- See note [Metavar map functions]
+-- | Get a quotation of a map between type names and Haskell variable references to types using the
+-- type name as the variable name.
+metavarMapType :: Set (TyName a) -> Q Exp
+metavarMapType ftvs = let ftvsL = fmap (nameString . unTyName) $ toList $ ftvs in
+    [|
+        let
+          subs :: [Quote (Type TyName ())]
+          subs = $(substs ftvsL)
+          qm :: Quote (Map.Map (BSL.ByteString) (Type TyName ()))
+          qm = do
+              quoted <- sequence subs
+              pure $ Map.fromList $ zip ftvsL quoted
+        in qm
+    |]
+
+metavarSubstType ::
+  Type TyName () ->
+  Map.Map BSL.ByteString (Type TyName ()) ->
+  Type TyName ()
+metavarSubstType ty tyMetavars = substTy
+                        (\n -> Map.lookup (nameString $ unTyName n) tyMetavars)
+                        ty
+
+metavarSubstTerm ::
+  Term TyName Name () ->
+  Map.Map BSL.ByteString (Type TyName ()) ->
+  Map.Map BSL.ByteString (Term TyName Name ()) ->
+  Term TyName Name ()
+metavarSubstTerm t tyMetavars termMetavars = substTerm
+                        (\n -> Map.lookup (nameString $ unTyName n) tyMetavars)
+                        (\n -> Map.lookup (nameString n) termMetavars)
+                        t
+
+-- | Runs a 'QuoteT' in the 'Q' context. Note that this uses 'runQuoteT', so does note preserve freshness.
+eval :: QuoteT (Except ParseError) a -> Q a
+eval c = case (runExcept $ runQuoteT c) of
+    Left e -> fail $ show e
+    Right p -> pure $ p
+
+unsafeDropErrors :: Except e a -> a
+unsafeDropErrors e = case (runExcept e) of
+    Right r -> r
+    Left _ -> error "Impossible!"
+
+{-- Note [Parsing and TH stages]
+We have a bit of a dilemma with the staging and parsing of PLC. We need the list of metavars at compile time
+so we can wire up the Haskell variable references, but we won't know the real variable names until runtime
+(since we're running things in 'Quote'!).
+
+The solution is kind of hacky, but works nicely: the linkage to metavar is done only by *name*, which does *not*
+include the unique tag. So we can parse the quasiquote at compile time to get the metavars, and then *again*
+at runtime to get the real program, and still be able to wire things up (since we're going to look for free vars at
+runtime by name, ignoring uniques).
+
+The runtime parse also assumes there will be no parse errors, since we've already checked, and there is nowhere
+to put them.
+
+Finally, we need to drop the lexer position annotations, since they're not terribly useful.
+-}
+
+compileTerm :: String -> Q Exp
+compileTerm s = do
+    compileTimeT <- eval $ parseTerm $ strToBs s
+    let
+        tyMetavars = metavarMapType (ftvTerm compileTimeT)
+        termMetavars = metavarMapTerm (fvTerm compileTimeT)
+    [|
+        let
+            quoted :: Quote (Term TyName Name ())
+            quoted = do
+                -- See note [Parsing and TH stages]
+                runtimeT <- (fmap discardAnnsTerm . mapInner (Identity . unsafeDropErrors) . parseTerm . strToBs) s
+                metavarSubstTerm runtimeT <$> $(tyMetavars) <*> $(termMetavars)
+        in quoted
+     |]
+
+compileType :: String -> Q Exp
+compileType s = do
+    compileTimeTy <- eval $ parseType $ strToBs s
+    let
+        tyMetavars = metavarMapType (ftvTy compileTimeTy)
+    [|
+        let
+            quoted :: Quote (Type TyName ())
+            quoted = do
+                -- See note [Parsing and TH stages]
+                runtimeTy <- (fmap discardAnnsTy . mapInner (Identity . unsafeDropErrors) . parseType . strToBs) s
+                metavarSubstType runtimeTy <$> $(tyMetavars)
+          in quoted
+      |]
+
+compileProgram :: String -> Q Exp
+compileProgram s = do
+    (Program _ _ compileTimeT) <- eval $ parseProgram $ strToBs s
+    let
+        tyMetavars = metavarMapType (ftvTerm compileTimeT)
+        termMetavars= metavarMapTerm (fvTerm compileTimeT)
+    [|
+        let
+            quoted :: Quote (Program TyName Name ())
+            quoted = do
+                -- See note [Parsing and TH stages]
+                (Program a v runtimeT) <- (fmap discardAnnsTerm . mapInner (Identity . unsafeDropErrors) . parseProgram . strToBs) s
+                Program a v <$> metavarSubstTerm runtimeT <$> $(tyMetavars) <*> $(termMetavars)
+        in quoted
+     |]
+
+-- | A quasiquoter for creating Plutus Core types.
+plcType :: QuasiQuoter
+plcType = QuasiQuoter {
+    quoteExp = compileType,
+    quoteDec = fail "Not implemented",
+    quotePat = fail "Not implemented",
+    quoteType = fail "Not implemented"
+}
+
+-- | A quasiquoter for creating Plutus Core terms.
+plcTerm :: QuasiQuoter
+plcTerm = QuasiQuoter {
+    quoteExp = compileTerm,
+    quoteDec = fail "Not implemented",
+    quotePat = fail "Not implemented",
+    quoteType = fail "Not implemented"
+ }
+
+-- | A quasiquoter for creating Plutus Core programs.
+plcProgram :: QuasiQuoter
+plcProgram = QuasiQuoter {
+    quoteExp = compileProgram,
+    quoteDec = fail "Not implemented",
+    quotePat = fail "Not implemented",
+    quoteType = fail "Not implemented"
+}

--- a/language-plutus-core/test/Evaluation/Generator.hs
+++ b/language-plutus-core/test/Evaluation/Generator.hs
@@ -20,7 +20,7 @@ module Evaluation.Generator
 import           Evaluation.Constant.GenTypedBuiltinSized
 import           Language.PlutusCore
 import           Language.PlutusCore.Constant
-import           PlutusPrelude
+import           PlutusPrelude hiding (hoist)
 
 import           Control.Monad.Morph
 import           Control.Monad.Reader

--- a/language-plutus-core/test/Quotation/Spec.hs
+++ b/language-plutus-core/test/Quotation/Spec.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE QuasiQuotes     #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Quotation.Spec (tests) where
+
+import           Language.PlutusCore
+import           Language.PlutusCore.TH
+import           Language.PlutusCore.Quote
+
+import qualified Data.ByteString.Lazy   as BSL
+import           Data.Text.Encoding     (encodeUtf8)
+import qualified PlutusPrelude          as PP
+
+import           Test.Tasty
+import           Test.Tasty.Golden
+
+tests :: TestTree
+tests = testGroup "quasiquoter" [
+  asGolden (runQuote unit) "test/Quotation/unit.plc",
+  asGolden (runQuote one) "test/Quotation/one.plc",
+  asGolden (runQuote bool) "test/Quotation/bool.plc",
+  asGolden (runQuote true) "test/Quotation/true.plc",
+  asGolden (runQuote false) "test/Quotation/false.plc"
+ ]
+
+asGolden :: PP.Debug a => a -> TestName -> TestTree
+asGolden a file = goldenVsString file (file ++ ".golden") (pure $ showTest a)
+
+showTest :: PP.Debug a => a -> BSL.ByteString
+showTest = BSL.fromStrict . encodeUtf8 . debugText
+
+unit :: Quote (Type TyName ())
+unit = [plcType|(all a (type) (fun a a))|]
+
+one :: Quote (Term TyName Name ())
+one = [plcTerm|(abs a (type) (lam x a x))|]
+
+bool :: Quote (Type TyName ())
+bool = [plcType|(all a (type) (fun (fun unit a) (fun (fun unit a) a))) |]
+
+true :: Quote (Term TyName Name ())
+true = [plcTerm|(abs a (type) (lam x (fun unit a) (lam y (fun unit a) [x one])))|]
+
+false :: Quote (Term TyName Name ())
+false = [plcTerm|(abs a (type) (lam x (fun unit a) (lam y (fun unit a) [x one])))|]

--- a/language-plutus-core/test/Quotation/bool.plc.golden
+++ b/language-plutus-core/test/Quotation/bool.plc.golden
@@ -1,0 +1,1 @@
+(all a_0 (type) (fun (fun (all a_2 (type) (fun a_2 a_2)) a_0) (fun (fun (all a_2 (type) (fun a_2 a_2)) a_0) a_0)))

--- a/language-plutus-core/test/Quotation/false.plc.golden
+++ b/language-plutus-core/test/Quotation/false.plc.golden
@@ -1,0 +1,1 @@
+(abs a_0 (type) (lam x_1 (fun (all a_5 (type) (fun a_5 a_5)) a_0) (lam y_3 (fun (all a_5 (type) (fun a_5 a_5)) a_0) [ x_1 (abs a_6 (type) (lam x_7 a_6 x_7)) ])))

--- a/language-plutus-core/test/Quotation/one.plc.golden
+++ b/language-plutus-core/test/Quotation/one.plc.golden
@@ -1,0 +1,1 @@
+(abs a_0 (type) (lam x_1 a_0 x_1))

--- a/language-plutus-core/test/Quotation/true.plc.golden
+++ b/language-plutus-core/test/Quotation/true.plc.golden
@@ -1,0 +1,1 @@
+(abs a_0 (type) (lam x_1 (fun (all a_5 (type) (fun a_5 a_5)) a_0) (lam y_3 (fun (all a_5 (type) (fun a_5 a_5)) a_0) [ x_1 (abs a_6 (type) (lam x_7 a_6 x_7)) ])))

--- a/language-plutus-core/test/Quotation/unit.plc.golden
+++ b/language-plutus-core/test/Quotation/unit.plc.golden
@@ -1,0 +1,1 @@
+(all a_0 (type) (fun a_0 a_0))

--- a/language-plutus-core/test/Spec.hs
+++ b/language-plutus-core/test/Spec.hs
@@ -7,6 +7,7 @@ import qualified Data.ByteString.Lazy    as BSL
 import qualified Data.Text               as T
 import           Data.Text.Encoding      (encodeUtf8)
 import           Evaluation.Constant.All
+import qualified Quotation.Spec as Quotation
 import           Generators
 import           Hedgehog                hiding (Var, annotate)
 import           Language.PlutusCore
@@ -74,6 +75,7 @@ allTests plcFiles rwFiles typeFiles = testGroup "all tests"
     , testsRewrite rwFiles
     , testsType typeFiles
     , test_constantApplication
+    , Quotation.tests
     ]
 
 type TestFunction a = BSL.ByteString -> Either a T.Text

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -42050,7 +42050,9 @@ license = stdenv.lib.licenses.bsd3;
 , tasty-golden
 , tasty-hedgehog
 , tasty-hunit
+, template-haskell
 , text
+, th-lift-instances
 , transformers
 }:
 mkDerivation {
@@ -42071,7 +42073,9 @@ microlens
 mtl
 prettyprinter
 recursion-schemes
+template-haskell
 text
+th-lift-instances
 transformers
 ];
 libraryToolDepends = [


### PR DESCRIPTION
This adds a quasiquoter for PLC to `language-plutus-core`. In order to get it scope-safe I had to implement a capture-avoiding substitution function - I've put this in its own module since it seems reusable, and no doubt other people can make it more efficient!

I think this should be useful both for defining terms in `language-plutus-core` itself (e.g. in `Constant/Prelude.hs`), and when generating PLC programs in the PlutusTx compiler.

## Implementation notes

The approach I've taken for antiquotation is to use free object-level variables as metavariables. It's perhaps easiest to see how this works out with an example (taken from the tests):
```
unit = [plcType|(all a (type) (fun a a))|]
one = [plcTerm|(abs a (type) (lam x a x))|]
bool = [plcType|(all a (type) (fun (fun unit a) (fun (fun unit a) a))) |]
true = [plcTerm|(abs a (type) (lam x (fun unit a) (lam y (fun unit a) [x one])))|]
false = [plcTerm|(abs a (type) (lam x (fun unit a) (lam y (fun unit a) [x one])))|]
```
So we can reference `unit`, for example, simply by writing an unbound `unit` type variable. (Yes you will get a type error, albeit not a great one, if you use a type instead of a term and vice versa, and a better error if the referenced variable doesn't exist.)

This is scope-safe as you can see from the test output (which is rendered with `Debug` to verify this). The output for `bool` is:
```
(all a_0 (type) (fun (fun (all a_2 (type) (fun a_2 a_2)) a_0) (fun (fun (all a_2 (type) (fun a_2 a_2)) a_0) a_0)))
```
so even though we've use `a` for all the variables, the uniques have been modified so they don't clash. This is something of a brute-force method, but it seems to work.

The TH is, eventually, quite straightforward. I did quite a lot of head-scratching trying to work out how to do something like `[| captureAvoidingSubstTerm (\n -> $(substFun n)) t |]` - this violates the staging restriction on `n`. In the end, what I came up with was reifying the entire map that encodes the function as a quote, and then building the function back up out of that. Better suggestions welcome!