### PR TITLE
Minor dev env improvements

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -51,7 +51,8 @@ let
   plutusPkgs = (import ./pkgs { inherit pkgs; }).override {
     overrides = self: super: {
       plutus-prototype = addRealTimeTestLogs (filterSource super.plutus-prototype);
-      language-plutus-core = doHaddockHydra (addRealTimeTestLogs (filterSource super.language-plutus-core));
+      # we want to enable benchmarking, which also means we have criterion in the corresponding env
+      language-plutus-core = doBenchmark (doHaddockHydra (addRealTimeTestLogs (filterSource super.language-plutus-core)));
     };
   };
   other = rec {

--- a/language-plutus-core/shell.nix
+++ b/language-plutus-core/shell.nix
@@ -1,0 +1,1 @@
+(import ../. {}).language-plutus-core.env

--- a/plutus-prototype/shell.nix
+++ b/plutus-prototype/shell.nix
@@ -1,0 +1,1 @@
+(import ../. {}).plutus-prototype.env


### PR DESCRIPTION
- Add `shell.nix` files in project subdirs for convenience
- Add `doBenchmark` to `language-plutus-core` so we get `criterion` in the corresponding shell env