### PR TITLE
Made the 'run-ck' executable non-interactive

### DIFF
--- a/language-plutus-core/README.md
+++ b/language-plutus-core/README.md
@@ -32,7 +32,6 @@ The Haskell package `language-plutus-core` implements a range of functionality f
 
 * API documentation with Haddock
 
-
 ## Design
 
 ### Parser and pretty printer
@@ -77,4 +76,10 @@ data CkEvalResult
     | CkEvalFailure
 ```
 
-There is an executable that runs programs on the CK machine. In order to use it, type in your terminal `stack build && stack exec language-plutus-core-run-ck` and follow the instructions.
+There is an executable that runs programs on the CK machine. In order to install it, type in your terminal `stack install language-plutus-core-run-ck`. Once the build finishes, you can run `language-plutus-core-run-ck` and type a program, the program will be run and the result will be printed.
+
+An examle of usage:
+
+```
+echo "(program 0.1.0 [(lam x [(con integer) (con 2)] x) (con 2 ! 4)])" | language-plutus-core-run-ck
+```

--- a/language-plutus-core/README.md
+++ b/language-plutus-core/README.md
@@ -76,7 +76,7 @@ data CkEvalResult
     | CkEvalFailure
 ```
 
-There is an executable that runs programs on the CK machine. In order to install it, type in your terminal `stack install language-plutus-core-run-ck`. Once the build finishes, you can run `language-plutus-core-run-ck` and type a program, the program will be run and the result will be printed.
+There is an executable that runs programs on the CK machine. In order to install it globally, type in your terminal `stack install language-plutus-core-run-ck`. Once the build finishes, you can run `language-plutus-core-run-ck` and type a program, the program will be run and the result will be printed.
 
 An examle of usage:
 


### PR DESCRIPTION
Lucas said he now thinks a non-interactive version is preferable, so it's non-interactive now by default.
The interactive version is in the code, but I don't bother to add flags right now, because I may prefer to just use REPL in emacs.