### PR TITLE
language-plutus-core: use state-based mechanism for fresh names

### DIFF
--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -31,6 +31,7 @@ library
         Language.PlutusCore
         Language.PlutusCore.CkMachine
         Language.PlutusCore.Constant
+        Language.PlutusCore.Quote
         PlutusPrelude
     build-tools: alex -any, happy >=1.17.1
     hs-source-dirs: src prelude recursion
@@ -71,7 +72,6 @@ library
         text -any,
         prettyprinter -any,
         microlens -any,
-        value-supply -any,
         composition-prelude -any
 
     if (flag(development) && impl(ghc <8.4))

--- a/language-plutus-core/prelude/PlutusPrelude.hs
+++ b/language-plutus-core/prelude/PlutusPrelude.hs
@@ -28,15 +28,12 @@ module PlutusPrelude ( -- * Reëxports from base
                      , (.*)
                      -- * Custom functions
                      , prettyString
-                     , freshInt
-                     , dropFresh
                      , prettyText
                      , debugText
                      , render
                      , repeatM
                      , (?)
                      , Debug (..)
-                     , Fresh
                      -- Reëxports from "Data.Text.Prettyprint.Doc"
                      , (<+>)
                      , parens
@@ -50,7 +47,6 @@ import           Control.Composition                     ((.*))
 import           Control.DeepSeq                         (NFData)
 import           Control.Exception                       (Exception, throw)
 import           Control.Monad                           (guard, join)
-import           Control.Monad.Trans.Reader
 import           Data.Bifunctor                          (first, second)
 import           Data.Bool                               (bool)
 import           Data.Foldable                           (fold, toList)
@@ -59,7 +55,6 @@ import           Data.List                               (foldl')
 import           Data.List.NonEmpty                      (NonEmpty (..))
 import           Data.Maybe                              (isJust)
 import           Data.Semigroup
-import           Data.Supply
 import qualified Data.Text                               as T
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Render.String (renderString)
@@ -68,7 +63,6 @@ import           Data.Typeable                           (Typeable)
 import           Data.Word                               (Word8)
 import           GHC.Generics                            (Generic)
 import           GHC.Natural                             (Natural)
-import           System.IO.Unsafe
 
 infixr 2 ?
 
@@ -97,26 +91,6 @@ newtype PairT b f a = PairT
 
 instance Functor f => Functor (PairT b f) where
     fmap f (PairT p) = PairT $ fmap (fmap f) p
-
-newtype Fresh a = Fresh
-    { unFresh :: Reader (Supply Int) a
-    } deriving (Functor)
-
-instance Applicative Fresh where
-    pure                = Fresh . pure
-    Fresh g <*> Fresh f = Fresh . reader $ \s ->
-        let (s1, s2) = split2 s in runReader g s1 (runReader f s2)
-
-instance Monad Fresh where
-    Fresh g >>= h = Fresh . reader $ \s ->
-        let (s1, s2) = split2 s in runReader (unFresh . h $ runReader g s1) s2
-
-freshInt :: Fresh Int
-freshInt = Fresh $ reader supplyValue
-
-dropFresh :: Fresh a -> a
-dropFresh (Fresh f) = runReader f $ unsafePerformIO newEnumSupply
-{-# NOINLINE dropFresh #-}
 
 (?) :: Alternative f => Bool -> a -> f a
 (?) b x = x <$ guard b

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -74,6 +74,8 @@ import           Language.PlutusCore.Renamer
 import           Language.PlutusCore.Type
 import           Language.PlutusCore.TypeSynthesis
 import           PlutusPrelude
+import           Control.Monad.Except
+import           Control.Monad.State
 
 newtype Configuration = Configuration Bool
 
@@ -100,7 +102,7 @@ debugCfg = Configuration True
 -- | Parse and rewrite so that names are globally unique, not just unique within
 -- their scope.
 parseScoped :: BSL.ByteString -> Either ParseError (Program TyName Name AlexPosn)
-parseScoped = fmap (uncurry rename) . parseST
+parseScoped str = fmap (\(p, s) -> rename s p) $ runExcept $ runStateT (parseST str) emptyIdentifierState
 
 programType :: Natural -- ^ Gas provided to typechecker
             -> TypeState a

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -56,8 +56,6 @@ module Language.PlutusCore
     -- * Base functors
     , TermF (..)
     , TypeF (..)
-    , Fresh
-    , dropFresh
     ) where
 
 import qualified Data.ByteString.Lazy              as BSL

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Make.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Make.hs
@@ -49,7 +49,7 @@ makeBuiltinSize size size' = checkBoundsSize size size' ? BuiltinSize () size
 
 -- | Coerce a 'Bool' to the corresponding PLC's @boolean@.
 makeDupBuiltinBool :: Bool -> Value TyName Name ()
-makeDupBuiltinBool b = runQ $ if b then getBuiltinTrue else getBuiltinFalse
+makeDupBuiltinBool b = runQuote $ if b then getBuiltinTrue else getBuiltinFalse
 
 -- | Coerce a Haskell value to the corresponding PLC constant indexed by size
 -- checking all constraints (e.g. an 'Integer' is in appropriate bounds) along the way.

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Make.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Make.hs
@@ -11,6 +11,7 @@ module Language.PlutusCore.Constant.Make
 import           PlutusPrelude
 import           Language.PlutusCore.Type
 import           Language.PlutusCore.Name
+import           Language.PlutusCore.Quote
 import           Language.PlutusCore.Constant.Prelude
 import           Language.PlutusCore.Constant.Typed
 
@@ -48,7 +49,7 @@ makeBuiltinSize size size' = checkBoundsSize size size' ? BuiltinSize () size
 
 -- | Coerce a 'Bool' to the corresponding PLC's @boolean@.
 makeDupBuiltinBool :: Bool -> Value TyName Name ()
-makeDupBuiltinBool b = dropFresh $ if b then getBuiltinTrue else getBuiltinFalse
+makeDupBuiltinBool b = runQ $ if b then getBuiltinTrue else getBuiltinFalse
 
 -- | Coerce a Haskell value to the corresponding PLC constant indexed by size
 -- checking all constraints (e.g. an 'Integer' is in appropriate bounds) along the way.

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Prelude.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Prelude.hs
@@ -13,6 +13,7 @@ module Language.PlutusCore.Constant.Prelude
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Type
 import           PlutusPrelude
+import           Language.PlutusCore.Quote
 
 type Size = Natural
 type Value = Term
@@ -20,7 +21,7 @@ type Value = Term
 -- | Church-encoded '()' as a PLC type.
 --
 -- > all (A :: *). A -> A
-getBuiltinUnit :: Fresh (Type TyName ())
+getBuiltinUnit :: Q (Type TyName ())
 getBuiltinUnit = do
     a <- freshTyName () "A"
     return
@@ -31,7 +32,7 @@ getBuiltinUnit = do
 -- | Church-encoded '()' as a PLC term.
 --
 -- > /\(A :: *) -> \(x : A) -> x
-getBuiltinUnitval :: Fresh (Value TyName Name ())
+getBuiltinUnitval :: Q (Value TyName Name ())
 getBuiltinUnitval = do
     a <- freshTyName () "A"
     x <- freshName () "x"
@@ -43,7 +44,7 @@ getBuiltinUnitval = do
 -- | Church-encoded '()' as a PLC type.
 --
 -- > all (A :: *). (() -> A) -> (() -> A) -> A
-getBuiltinBool :: Fresh (Type TyName ())
+getBuiltinBool :: Q (Type TyName ())
 getBuiltinBool = do
     a <- freshTyName () "A"
     unit <- getBuiltinUnit
@@ -56,7 +57,7 @@ getBuiltinBool = do
 -- | Church-encoded 'True' as a PLC term.
 --
 -- > /\(A :: *) -> \(x y : () -> A) -> x ()
-getBuiltinTrue :: Fresh (Value TyName Name ())
+getBuiltinTrue :: Q (Value TyName Name ())
 getBuiltinTrue = do
     builtinUnit <- getBuiltinUnit
     builtinUnitval <- getBuiltinUnitval
@@ -73,7 +74,7 @@ getBuiltinTrue = do
 -- | Church-encoded 'False' as a PLC term.
 --
 -- > /\(A :: *) -> \(x y : () -> A) -> y ()
-getBuiltinFalse :: Fresh (Value TyName Name ())
+getBuiltinFalse :: Q (Value TyName Name ())
 getBuiltinFalse = do
     builtinUnit <- getBuiltinUnit
     builtinUnitval <- getBuiltinUnitval

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Prelude.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Prelude.hs
@@ -21,7 +21,7 @@ type Value = Term
 -- | Church-encoded '()' as a PLC type.
 --
 -- > all (A :: *). A -> A
-getBuiltinUnit :: Q (Type TyName ())
+getBuiltinUnit :: Quote (Type TyName ())
 getBuiltinUnit = do
     a <- freshTyName () "A"
     return
@@ -32,7 +32,7 @@ getBuiltinUnit = do
 -- | Church-encoded '()' as a PLC term.
 --
 -- > /\(A :: *) -> \(x : A) -> x
-getBuiltinUnitval :: Q (Value TyName Name ())
+getBuiltinUnitval :: Quote (Value TyName Name ())
 getBuiltinUnitval = do
     a <- freshTyName () "A"
     x <- freshName () "x"
@@ -44,7 +44,7 @@ getBuiltinUnitval = do
 -- | Church-encoded '()' as a PLC type.
 --
 -- > all (A :: *). (() -> A) -> (() -> A) -> A
-getBuiltinBool :: Q (Type TyName ())
+getBuiltinBool :: Quote (Type TyName ())
 getBuiltinBool = do
     a <- freshTyName () "A"
     unit <- getBuiltinUnit
@@ -57,7 +57,7 @@ getBuiltinBool = do
 -- | Church-encoded 'True' as a PLC term.
 --
 -- > /\(A :: *) -> \(x y : () -> A) -> x ()
-getBuiltinTrue :: Q (Value TyName Name ())
+getBuiltinTrue :: Quote (Value TyName Name ())
 getBuiltinTrue = do
     builtinUnit <- getBuiltinUnit
     builtinUnitval <- getBuiltinUnitval
@@ -74,7 +74,7 @@ getBuiltinTrue = do
 -- | Church-encoded 'False' as a PLC term.
 --
 -- > /\(A :: *) -> \(x y : () -> A) -> y ()
-getBuiltinFalse :: Q (Value TyName Name ())
+getBuiltinFalse :: Quote (Value TyName Name ())
 getBuiltinFalse = do
     builtinUnit <- getBuiltinUnit
     builtinUnitval <- getBuiltinUnitval

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Typed.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Typed.hs
@@ -45,6 +45,7 @@ import           Language.PlutusCore.Constant.Prelude
 import           Language.PlutusCore.Lexer.Type       (BuiltinName (..), TypeBuiltin (..), prettyBytes)
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Type
+import           Language.PlutusCore.Quote
 import           PlutusPrelude
 
 import qualified Data.ByteString.Lazy.Char8           as BSL
@@ -136,14 +137,14 @@ typedBuiltinSizedToType TypedBuiltinSizedInt  = TyBuiltin () TyInteger
 typedBuiltinSizedToType TypedBuiltinSizedBS   = TyBuiltin () TyByteString
 typedBuiltinSizedToType TypedBuiltinSizedSize = TyBuiltin () TySize
 
-typedBuiltinToType :: TypedBuiltin (TyName ()) a -> Fresh (Type TyName ())
+typedBuiltinToType :: TypedBuiltin (TyName ()) a -> Q (Type TyName ())
 typedBuiltinToType (TypedBuiltinSized sizeEntry tbs) =
     return . TyApp () (typedBuiltinSizedToType tbs) $ case sizeEntry of
         SizeValue size -> TyInt () size
         SizeBound name -> TyVar () name
 typedBuiltinToType TypedBuiltinBool                  = getBuiltinBool
 
-typeSchemeToType :: TypeScheme (TyName ()) a -> Fresh (Type TyName ())
+typeSchemeToType :: TypeScheme (TyName ()) a -> Q (Type TyName ())
 typeSchemeToType (TypeSchemeBuiltin builtin) = typedBuiltinToType builtin
 typeSchemeToType (TypeSchemeArrow schA schB) =
     TyFun () <$> typeSchemeToType schA <*> typeSchemeToType schB

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Typed.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Typed.hs
@@ -137,14 +137,14 @@ typedBuiltinSizedToType TypedBuiltinSizedInt  = TyBuiltin () TyInteger
 typedBuiltinSizedToType TypedBuiltinSizedBS   = TyBuiltin () TyByteString
 typedBuiltinSizedToType TypedBuiltinSizedSize = TyBuiltin () TySize
 
-typedBuiltinToType :: TypedBuiltin (TyName ()) a -> Q (Type TyName ())
+typedBuiltinToType :: TypedBuiltin (TyName ()) a -> Quote (Type TyName ())
 typedBuiltinToType (TypedBuiltinSized sizeEntry tbs) =
     return . TyApp () (typedBuiltinSizedToType tbs) $ case sizeEntry of
         SizeValue size -> TyInt () size
         SizeBound name -> TyVar () name
 typedBuiltinToType TypedBuiltinBool                  = getBuiltinBool
 
-typeSchemeToType :: TypeScheme (TyName ()) a -> Q (Type TyName ())
+typeSchemeToType :: TypeScheme (TyName ()) a -> Quote (Type TyName ())
 typeSchemeToType (TypeSchemeBuiltin builtin) = typedBuiltinToType builtin
 typeSchemeToType (TypeSchemeArrow schA schB) =
     TyFun () <$> typeSchemeToType schA <*> typeSchemeToType schB

--- a/language-plutus-core/src/Language/PlutusCore/Lexer.x
+++ b/language-plutus-core/src/Language/PlutusCore/Lexer.x
@@ -241,10 +241,10 @@ runAlexST input (Alex f) initial = liftError $ first alex_ust <$>
 
 runAlexST' :: forall a. ByteString.ByteString -> Alex a -> StateT IdentifierState (Except ParseError) a
 runAlexST' input al = StateT $ \is -> let
-      run :: Either ParseError (a, IdentifierState)
-      run = case runAlexST input al is of
-          Left e -> Left e
-          Right (s, a) -> Right (a, s)
+        run :: Either ParseError (a, IdentifierState)
+        run = case runAlexST input al is of
+            Left e -> Left e
+            Right (s, a) -> Right (a, s)
     in liftEither run
 
 }

--- a/language-plutus-core/src/Language/PlutusCore/Lexer.x
+++ b/language-plutus-core/src/Language/PlutusCore/Lexer.x
@@ -1,22 +1,29 @@
 {
     {-# OPTIONS_GHC -fno-warn-unused-imports #-}
-    {-# LANGUAGE DeriveAnyClass     #-}
-    {-# LANGUAGE DeriveGeneric      #-}
-    {-# LANGUAGE OverloadedStrings  #-}
-    {-# LANGUAGE StandaloneDeriving #-}
+    {-# LANGUAGE DeriveAnyClass      #-}
+    {-# LANGUAGE DeriveGeneric       #-}
+    {-# LANGUAGE OverloadedStrings   #-}
+    {-# LANGUAGE StandaloneDeriving  #-}
+    {-# LANGUAGE ScopedTypeVariables #-}
     module Language.PlutusCore.Lexer ( alexMonadScan
                                      , runAlex
                                      , runAlexST
+                                     , runAlexST'
                                      -- * Types
                                      , AlexPosn (..)
                                      , Alex (..)
+                                     , ParseError (..)
                                      ) where
 
 import PlutusPrelude
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.Char8 as ASCII
+import qualified Data.Text as T
+import Data.Text.Prettyprint.Doc.Internal (Doc (Text))
 import Language.PlutusCore.Lexer.Type
 import Language.PlutusCore.Name
+import Control.Monad.Except
+import Control.Monad.State
 
 }
 
@@ -209,14 +216,38 @@ get_pos = gets_alex alex_pos
 alexEOF :: Alex (Token AlexPosn)
 alexEOF = EOF <$> get_pos
 
-runAlexST :: ByteString.ByteString -> Alex a -> Either String (IdentifierState, a)
-runAlexST input (Alex f) = first alex_ust <$> 
+-- TODO: debug info should carry parser/lexer state
+-- | An error encountered during parsing.
+data ParseError = LexErr String
+                | Unexpected (Token AlexPosn)
+                | Overflow AlexPosn Natural Integer 
+                deriving (Show, Eq, Generic, NFData)
+
+instance Pretty ParseError where
+    pretty (LexErr s) = "Lexical error:" <+> Text (length s) (T.pack s)
+    pretty (Unexpected t) = "Unexpected" <+> squotes (pretty t) <+> "at" <+> pretty (loc t)
+    pretty (Overflow pos _ _) = "Integer overflow at" <+> pretty pos <> "."
+
+liftError :: Either String a -> Either ParseError a
+liftError(Left s) = Left $ LexErr s
+liftError(Right a) = Right $ a
+
+runAlexST :: ByteString.ByteString -> Alex a -> IdentifierState -> Either ParseError (IdentifierState, a)
+runAlexST input (Alex f) initial = liftError $ first alex_ust <$>
     f (AlexState { alex_pos = alexStartPos
                  , alex_bpos = 0
                  , alex_inp = input
                  , alex_chr = '\n'
-                 , alex_ust = alexInitUserState
+                 , alex_ust = initial
                  , alex_scd = 0
                  })
+
+runAlexST' :: forall a. ByteString.ByteString -> Alex a -> StateT IdentifierState (Except ParseError) a
+runAlexST' input al = StateT $ \is -> let
+      run :: Either ParseError (a, IdentifierState)
+      run = case runAlexST input al is of
+          Left e -> Left e
+          Right (s, a) -> Right (a, s)
+    in liftEither run
 
 }

--- a/language-plutus-core/src/Language/PlutusCore/Name.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Name.hs
@@ -13,8 +13,6 @@ module Language.PlutusCore.Name ( -- * Types
                                 -- * Functions
                                 , newIdentifier
                                 , emptyIdentifierState
-                                , freshName
-                                , freshTyName
                                 ) where
 
 import qualified Data.ByteString.Lazy as BSL
@@ -62,12 +60,6 @@ newIdentifier str st@(is, ss) = case M.lookup str ss of
     Nothing -> case IM.maxViewWithKey is of
         Just ((i,_), _) -> (Unique (i+1), (IM.insert (i+1) str is, M.insert str (Unique (i+1)) ss))
         Nothing    -> (Unique 0, (IM.singleton 0 str, M.singleton str (Unique 0)))
-
-freshName :: a -> BSL.ByteString -> Fresh (Name a)
-freshName attr name = Name attr name . Unique <$> freshInt
-
-freshTyName :: a -> BSL.ByteString -> Fresh (TyName a)
-freshTyName = fmap TyName .* freshName
 
 instance Pretty (Name a) where
     pretty (Name _ s _) = pretty (decodeUtf8 (BSL.toStrict s))

--- a/language-plutus-core/src/Language/PlutusCore/Name.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Name.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE FlexibleContexts           #-}
 
 module Language.PlutusCore.Name ( -- * Types
                                   IdentifierState
@@ -15,6 +16,7 @@ module Language.PlutusCore.Name ( -- * Types
                                 , emptyIdentifierState
                                 ) where
 
+import           Control.Monad.State
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.IntMap          as IM
 import qualified Data.Map             as M
@@ -54,12 +56,19 @@ newtype Unique = Unique { unUnique :: Int }
 -- | This is a naïve implementation of interned identifiers. In particular, it
 -- indexes things twice (once by 'Int', once by 'ByteString') to ensure fast
 -- lookups while lexing and otherwise.
-newIdentifier :: BSL.ByteString -> IdentifierState -> (Unique, IdentifierState)
-newIdentifier str st@(is, ss) = case M.lookup str ss of
-    Just k -> (k, st)
-    Nothing -> case IM.maxViewWithKey is of
-        Just ((i,_), _) -> (Unique (i+1), (IM.insert (i+1) str is, M.insert str (Unique (i+1)) ss))
-        Nothing    -> (Unique 0, (IM.singleton 0 str, M.singleton str (Unique 0)))
+newIdentifier :: (MonadState IdentifierState m) => BSL.ByteString -> m Unique
+newIdentifier str = do
+  (is, ss) <- get
+  case M.lookup str ss of
+    Just k -> pure k
+    Nothing ->
+      let key = case IM.maxViewWithKey is of
+            Just ((i,_), _) -> i+1
+            Nothing         -> 0
+      in do
+          let u = Unique key
+          put (IM.insert key str is, M.insert str u ss)
+          pure u
 
 instance Pretty (Name a) where
     pretty (Name _ s _) = pretty (decodeUtf8 (BSL.toStrict s))

--- a/language-plutus-core/src/Language/PlutusCore/Parser.y
+++ b/language-plutus-core/src/Language/PlutusCore/Parser.y
@@ -146,9 +146,7 @@ handleInteger x sz i = if isOverflow
           k = 8 ^ sz `div` 2
 
 parseST :: BSL.ByteString -> StateT IdentifierState (Except ParseError) (Program TyName Name AlexPosn)
-parseST str = do
-           run <- runAlexST' str (runExceptT parsePlutusCore)
-           liftEither run
+parseST str = liftEither $ runAlexST' str (runExceptT parsePlutusCore)
 
 -- | Parse a 'ByteString' containing a Plutus Core program, returning a 'ParseError' if syntactically invalid.
 --

--- a/language-plutus-core/src/Language/PlutusCore/Parser.y
+++ b/language-plutus-core/src/Language/PlutusCore/Parser.y
@@ -146,7 +146,7 @@ handleInteger x sz i = if isOverflow
           k = 8 ^ sz `div` 2
 
 parseST :: BSL.ByteString -> StateT IdentifierState (Except ParseError) (Program TyName Name AlexPosn)
-parseST str = liftEither $ runAlexST' str (runExceptT parsePlutusCore)
+parseST str =  runAlexST' str (runExceptT parsePlutusCore) >>= liftEither
 
 -- | Parse a 'ByteString' containing a Plutus Core program, returning a 'ParseError' if syntactically invalid.
 --

--- a/language-plutus-core/src/Language/PlutusCore/Quote.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Quote.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Language.PlutusCore.Quote (
+              runQT
+            , runQ
+            , freshName
+            , freshTyName
+            , parse
+            , QT
+            , Q
+            ) where
+
+import           Control.Monad.Except
+import           Control.Monad.State
+import qualified Data.ByteString.Lazy       as BSL
+import           Language.PlutusCore.Lexer  (AlexPosn)
+import           Language.PlutusCore.Name
+import           Language.PlutusCore.Parser (ParseError, parseST)
+import           Language.PlutusCore.Type
+import           Data.Functor.Identity
+import           PlutusPrelude
+
+-- | The "quotation" monad transformer. This allows creation of fresh names and parsing.
+newtype QT m a = QT { unQT :: StateT IdentifierState m a }
+  deriving (Functor, Applicative, Monad, MonadTrans, MonadState IdentifierState)
+
+-- | Run a quote from an empty identifier state.
+runQT ::  (Monad m) => QT m a -> m a
+runQT q = evalStateT (unQT q) emptyIdentifierState
+
+type Q a = QT Identity a
+
+-- | Run a quote from an empty identifier state.
+runQ :: Q a -> a
+runQ = runIdentity . runQT
+
+freshName :: (Monad m) => a -> BSL.ByteString -> QT m (Name a)
+freshName ann str = do
+  s1 <- get
+  let (u, s2) = newIdentifier str s1
+  put s2
+  pure $ Name ann str u
+
+freshTyName :: (Monad m) => a -> BSL.ByteString -> QT m (TyName a)
+freshTyName = fmap TyName .* freshName
+
+parse :: (MonadError ParseError m) => BSL.ByteString -> QT m (Program TyName Name AlexPosn)
+parse str = QT $ mapStateT (liftEither . runExcept) (parseST str)

--- a/language-plutus-core/src/Language/PlutusCore/Renamer.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Renamer.hs
@@ -143,7 +143,8 @@ rename :: IdentifierState -> Program TyName Name a -> Program TyName Name a
 rename (st, _, nextU) (Program x v p) = Program x v (evalState (renameTerm (Identifiers st') p) m)
     where st' = IM.fromList (zip keys keys)
           keys = IM.keys st
-          m = unUnique nextU
+          -- the next unique is one more than the maximum
+          m = (unUnique nextU)-1
 
 newtype Identifiers = Identifiers { _identifiers :: IM.IntMap Int }
 

--- a/language-plutus-core/src/Language/PlutusCore/Renamer.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Renamer.hs
@@ -140,10 +140,10 @@ annotateType (TyInt x n) = pure (TyInt x n)
 -- This renames terms so that they have a unique identifier. This is useful
 -- because of scoping.
 rename :: IdentifierState -> Program TyName Name a -> Program TyName Name a
-rename (st, _) (Program x v p) = Program x v (evalState (renameTerm (Identifiers st') p) m)
+rename (st, _, nextU) (Program x v p) = Program x v (evalState (renameTerm (Identifiers st') p) m)
     where st' = IM.fromList (zip keys keys)
           keys = IM.keys st
-          m = fst (IM.findMax st)
+          m = unUnique nextU
 
 newtype Identifiers = Identifiers { _identifiers :: IM.IntMap Int }
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -42052,13 +42052,14 @@ license = stdenv.lib.licenses.bsd3;
 , tasty-hunit
 , text
 , transformers
-, value-supply
 }:
 mkDerivation {
 
 pname = "language-plutus-core";
 version = "0.1.0.0";
 src = ./../language-plutus-core;
+isLibrary = true;
+isExecutable = true;
 libraryHaskellDepends = [
 array
 base
@@ -42072,11 +42073,16 @@ prettyprinter
 recursion-schemes
 text
 transformers
-value-supply
 ];
 libraryToolDepends = [
 alex
 happy
+];
+executableHaskellDepends = [
+base
+bytestring
+prettyprinter
+text
 ];
 testHaskellDepends = [
 base


### PR DESCRIPTION
Concretely, this allows us to interleave running the parser and creating terms manually and have them all use the same fresh identifier state.