### PR TITLE
language-plutus-core: move some things to default-extensions

### DIFF
--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -54,12 +54,19 @@ library
         Language.PlutusCore.Subst
         Data.Functor.Foldable.Monadic
     default-language: Haskell2010
-    other-extensions: DeriveGeneric DeriveAnyClass StandaloneDeriving
-                      GeneralizedNewtypeDeriving TypeFamilies DeriveFunctor
-                      DeriveFoldable DeriveTraversable FlexibleContexts OverloadedStrings
-                      DerivingStrategies MonadComprehensions FlexibleInstances
-                      ConstrainedClassMethods TupleSections GADTs RankNTypes 
-                      DeriveLift TemplateHaskell QuasiQuotes
+    default-extensions:
+        -- should be in base
+        ExplicitForAll ScopedTypeVariables
+        -- extensions to deriving
+        DeriveGeneric StandaloneDeriving DeriveLift
+        GeneralizedNewtypeDeriving DeriveFunctor DeriveFoldable
+        DeriveTraversable DerivingStrategies
+    other-extensions:
+        DeriveAnyClass
+        FlexibleContexts FlexibleInstances MultiParamTypeClasses
+        TypeFamilies OverloadedStrings MonadComprehensions
+        ConstrainedClassMethods TupleSections GADTs RankNTypes
+        TemplateHaskell QuasiQuotes
     ghc-options: -Wall -Wnoncanonical-monad-instances
                  -Wincomplete-uni-patterns -Wincomplete-record-updates
                  -Wredundant-constraints -Widentities

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Typed.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Typed.hs
@@ -1,6 +1,5 @@
 -- | See the 'docs/Constant application.md' article for how this module emerged.
 
-{-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE GADTs             #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}

--- a/language-plutus-core/src/Language/PlutusCore/Lexer.x
+++ b/language-plutus-core/src/Language/PlutusCore/Lexer.x
@@ -1,13 +1,7 @@
 {
     {-# OPTIONS_GHC -fno-warn-unused-imports #-}
     {-# LANGUAGE DeriveAnyClass        #-}
-    {-# LANGUAGE DeriveGeneric         #-}
     {-# LANGUAGE OverloadedStrings     #-}
-    {-# LANGUAGE StandaloneDeriving    #-}
-    {-# LANGUAGE DeriveLift            #-}
-    {-# LANGUAGE ScopedTypeVariables   #-}
-    {-# LANGUAGE FlexibleContexts      #-}
-    {-# LANGUAGE FlexibleInstances     #-}
     {-# LANGUAGE MultiParamTypeClasses #-}
     module Language.PlutusCore.Lexer ( alexMonadScan
                                      , runAlex

--- a/language-plutus-core/src/Language/PlutusCore/Lexer/Type.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Lexer/Type.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DeriveFunctor      #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE DeriveLift         #-}
-{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveAnyClass    #-}
 
 module Language.PlutusCore.Lexer.Type ( BuiltinName (..)
                                       , Version (..)

--- a/language-plutus-core/src/Language/PlutusCore/Name.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Name.hs
@@ -1,11 +1,6 @@
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveFunctor              #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DeriveLift                 #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE FlexibleContexts  #-}
 
 module Language.PlutusCore.Name ( -- * Types
                                   IdentifierState

--- a/language-plutus-core/src/Language/PlutusCore/Parser.y
+++ b/language-plutus-core/src/Language/PlutusCore/Parser.y
@@ -1,6 +1,4 @@
 {
-    {-# LANGUAGE DeriveAnyClass     #-}
-    {-# LANGUAGE DeriveGeneric      #-}
     {-# LANGUAGE OverloadedStrings  #-}
     module Language.PlutusCore.Parser ( parse
                                       , parseST

--- a/language-plutus-core/src/Language/PlutusCore/Quote.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Quote.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE ExplicitForAll             #-}
-{-# LANGUAGE Rank2Types                 #-}
+{-# LANGUAGE Rank2Types       #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module Language.PlutusCore.Quote (
               runQuoteT

--- a/language-plutus-core/src/Language/PlutusCore/Renamer.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Renamer.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE DeriveFunctor              #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleInstances #-}
 
 module Language.PlutusCore.Renamer ( rename
                                    , annotate

--- a/language-plutus-core/src/Language/PlutusCore/Type.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Type.hs
@@ -1,11 +1,6 @@
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DeriveFoldable     #-}
-{-# LANGUAGE DeriveFunctor      #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE DeriveLift         #-}
-{-# LANGUAGE DeriveTraversable  #-}
-{-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE TypeFamilies       #-}
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies      #-}
 
 module Language.PlutusCore.Type ( Term (..)
                                 , Type (..)

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE MonadComprehensions #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE FlexibleContexts    #-}
 
 module Language.PlutusCore.TypeSynthesis ( kindOf
                                          , typeOf


### PR DESCRIPTION
It got annoying.

- Obvious things (`ScopedTypeVariables`)
- Non-conflicty deriving things (in particular `DeriveAnyClass` sometimes conflicts with GND in an annoying way)
- Simple type class extensions for MTL-style classes.

`OverloadedStrings` is in nearly every file, so I think there's a good case for that too, but I'll leave it for now.