### PR TITLE
Quasiquoter: interpolated variables should not be in Quote

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore/Constant/Prelude.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Prelude.hs
@@ -36,27 +36,35 @@ getBuiltinUnitval = [plcTerm|(abs a (type) (lam x a x))|]
 --
 -- > all (A :: *). (() -> A) -> (() -> A) -> A
 getBuiltinBool :: Quote (Type TyName ())
-getBuiltinBool = [plcType|(all a (type)
-                         (fun
-                         (fun getBuiltinUnit a)
-                         (fun
-                         (fun getBuiltinUnit a)
-                         a)))|]
+getBuiltinBool = do
+    unit <- getBuiltinUnit
+    [plcType|(all a (type)
+              (fun
+              (fun unit a)
+              (fun
+              (fun unit a)
+              a)))|]
 
 -- | Church-encoded 'True' as a PLC term.
 --
 -- > /\(A :: *) -> \(x y : () -> A) -> x ()
 getBuiltinTrue :: Quote (Value TyName Name ())
-getBuiltinTrue = [plcTerm|(abs a (type)
-                         (lam x (fun getBuiltinUnit a)
-                         (lam y (fun getBuiltinUnit a)
-                         [x getBuiltinUnitval])))|]
+getBuiltinTrue = do
+    unit <- getBuiltinUnit
+    unitval <- getBuiltinUnitval
+    [plcTerm|(abs a (type)
+              (lam x (fun unit a)
+              (lam y (fun unit a)
+              [x unitval])))|]
 
 -- | Church-encoded 'False' as a PLC term.
 --
 -- > /\(A :: *) -> \(x y : () -> A) -> y ()
 getBuiltinFalse :: Quote (Value TyName Name ())
-getBuiltinFalse = [plcTerm|(abs a (type)
-                         (lam x (fun getBuiltinUnit a)
-                         (lam y (fun getBuiltinUnit a)
-                         [y getBuiltinUnitval])))|]
+getBuiltinFalse = do
+    unit <- getBuiltinUnit
+    unitval <- getBuiltinUnitval
+    [plcTerm|(abs a (type)
+              (lam x (fun unit a)
+              (lam y (fun unit a)
+              [y unitval])))|]

--- a/language-plutus-core/src/Language/PlutusCore/TH.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TH.hs
@@ -53,13 +53,11 @@ metavarMapTerm :: Set.Set (Name a) -> Q Exp
 metavarMapTerm ftvs = let ftvsL = fmap nameString $ toList $ ftvs in
     [|
         let
-            subs :: [Quote (Term TyName Name ())]
+            subs :: [(Term TyName Name ())]
             subs = $(substs ftvsL)
-            qm :: Quote (Map.Map (BSL.ByteString) (Term TyName Name ()))
-            qm = do
-                quoted <- sequence subs
-                pure $ Map.fromList $ zip ftvsL quoted
-        in qm
+            qm :: Map.Map (BSL.ByteString) (Term TyName Name ())
+            qm = Map.fromList $ zip ftvsL subs
+        in pure qm
     |]
 
 -- See note [Metavar map functions]
@@ -69,13 +67,11 @@ metavarMapType :: Set.Set (TyName a) -> Q Exp
 metavarMapType ftvs = let ftvsL = fmap (nameString . unTyName) $ toList $ ftvs in
     [|
         let
-          subs :: [Quote (Type TyName ())]
+          subs :: [(Type TyName ())]
           subs = $(substs ftvsL)
-          qm :: Quote (Map.Map (BSL.ByteString) (Type TyName ()))
-          qm = do
-              quoted <- sequence subs
-              pure $ Map.fromList $ zip ftvsL quoted
-        in qm
+          qm :: Map.Map (BSL.ByteString) (Type TyName ())
+          qm = Map.fromList $ zip ftvsL subs
+        in pure qm
     |]
 
 metavarSubstType ::

--- a/language-plutus-core/test/Quotation/Spec.hs
+++ b/language-plutus-core/test/Quotation/Spec.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE QuasiQuotes     #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Quotation.Spec (tests) where
 
@@ -20,7 +21,8 @@ tests = testGroup "quasiquoter" [
   asGolden (runQuote one) "test/Quotation/one.plc",
   asGolden (runQuote bool) "test/Quotation/bool.plc",
   asGolden (runQuote true) "test/Quotation/true.plc",
-  asGolden (runQuote false) "test/Quotation/false.plc"
+  asGolden (runQuote false) "test/Quotation/false.plc",
+  asGolden (runQuote free) "test/Quotation/free.plc"
  ]
 
 asGolden :: PP.Debug a => a -> TestName -> TestTree
@@ -36,10 +38,24 @@ one :: Quote (Term TyName Name ())
 one = [plcTerm|(abs a (type) (lam x a x))|]
 
 bool :: Quote (Type TyName ())
-bool = [plcType|(all a (type) (fun (fun unit a) (fun (fun unit a) a))) |]
+bool = do
+    u <- unit
+    [plcType|(all a (type) (fun (fun u a) (fun (fun u a) a))) |]
 
 true :: Quote (Term TyName Name ())
-true = [plcTerm|(abs a (type) (lam x (fun unit a) (lam y (fun unit a) [x one])))|]
+true = do
+    u <- unit
+    o <- one
+    [plcTerm|(abs a (type) (lam x (fun u a) (lam y (fun u a) [x o])))|]
 
 false :: Quote (Term TyName Name ())
-false = [plcTerm|(abs a (type) (lam x (fun unit a) (lam y (fun unit a) [x one])))|]
+false = do
+    u <- unit
+    o <- one
+    [plcTerm|(abs a (type) (lam x (fun u a) (lam y (fun u a) [x o])))|]
+
+free :: Quote (Term TyName Name ())
+free = do
+  -- both occurences should be the same variable
+  f <- TyVar () <$> freshTyName () "free"
+  [plcTerm|[(lam x f x) (lam x f x)]|]

--- a/language-plutus-core/test/Quotation/bool.plc.golden
+++ b/language-plutus-core/test/Quotation/bool.plc.golden
@@ -1,1 +1,1 @@
-(all a_0 (type) (fun (fun (all a_2 (type) (fun a_2 a_2)) a_0) (fun (fun (all a_2 (type) (fun a_2 a_2)) a_0) a_0)))
+(all a_1 (type) (fun (fun (all a_0 (type) (fun a_0 a_0)) a_1) (fun (fun (all a_0 (type) (fun a_0 a_0)) a_1) a_1)))

--- a/language-plutus-core/test/Quotation/false.plc.golden
+++ b/language-plutus-core/test/Quotation/false.plc.golden
@@ -1,1 +1,1 @@
-(abs a_0 (type) (lam x_1 (fun (all a_5 (type) (fun a_5 a_5)) a_0) (lam y_3 (fun (all a_5 (type) (fun a_5 a_5)) a_0) [ x_1 (abs a_6 (type) (lam x_7 a_6 x_7)) ])))
+(abs a_3 (type) (lam x_4 (fun (all a_0 (type) (fun a_0 a_0)) a_3) (lam y_6 (fun (all a_0 (type) (fun a_0 a_0)) a_3) [ x_4 (abs a_1 (type) (lam x_2 a_1 x_2)) ])))

--- a/language-plutus-core/test/Quotation/free.plc.golden
+++ b/language-plutus-core/test/Quotation/free.plc.golden
@@ -1,0 +1,1 @@
+[ (lam x_1 free_0 x_1) (lam x_1 free_0 x_1) ]

--- a/language-plutus-core/test/Quotation/true.plc.golden
+++ b/language-plutus-core/test/Quotation/true.plc.golden
@@ -1,1 +1,1 @@
-(abs a_0 (type) (lam x_1 (fun (all a_5 (type) (fun a_5 a_5)) a_0) (lam y_3 (fun (all a_5 (type) (fun a_5 a_5)) a_0) [ x_1 (abs a_6 (type) (lam x_7 a_6 x_7)) ])))
+(abs a_3 (type) (lam x_4 (fun (all a_0 (type) (fun a_0 a_0)) a_3) (lam y_6 (fun (all a_0 (type) (fun a_0 a_0)) a_3) [ x_4 (abs a_1 (type) (lam x_2 a_1 x_2)) ])))

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -42070,6 +42070,7 @@ composition-prelude
 containers
 deepseq
 microlens
+mmorph
 mtl
 prettyprinter
 recursion-schemes


### PR DESCRIPTION
Usually you want to bind interpolated variables in a do block
beforehand, in which case they will not be in `Quote`. This is important
if you want to actually share a name - otherwise the computation will be
run at each occurrence, meaning you get different names!

(Test changes are due to the fact that the variables are now "run" before the main quoted term, rather than vice versa, which is what it was before)