### PR TITLE
Quote: add interface to annotation and typechecking

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore/Quote.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Quote.hs
@@ -10,19 +10,29 @@ module Language.PlutusCore.Quote (
             , parseProgram
             , parseTerm
             , parseType
+            , annotateProgram
+            , annotateTerm
+            , typecheckProgram
+            , typecheckTerm
             , QuoteT
             , Quote
             ) where
 
 import           Control.Monad.Except
-import           Control.Monad.Morph        as MM
+import           Control.Monad.Morph               as MM
 import           Control.Monad.State
-import qualified Data.ByteString.Lazy       as BSL
+
+import qualified Data.ByteString.Lazy              as BSL
 import           Data.Functor.Identity
-import           Language.PlutusCore.Lexer  (AlexPosn)
+import qualified Data.IntMap                       as IM
+
+import           Language.PlutusCore.Error
+import           Language.PlutusCore.Lexer         (AlexPosn)
 import           Language.PlutusCore.Name
-import           Language.PlutusCore.Parser (ParseError, parseST, parseTermST, parseTypeST)
+import           Language.PlutusCore.Parser        (ParseError, parseST, parseTermST, parseTypeST)
+import           Language.PlutusCore.Renamer
 import           Language.PlutusCore.Type
+import           Language.PlutusCore.TypeSynthesis
 import           PlutusPrelude
 
 -- | The state contains the "next" 'Unique' that should be used for a name
@@ -64,24 +74,53 @@ freshName ann str = Name ann str <$> freshUnique
 freshTyName :: (Monad m) => a -> BSL.ByteString -> QuoteT m (TyName a)
 freshTyName = fmap TyName .* freshName
 
-mapParseRun :: (MonadError ParseError m) => StateT IdentifierState (Except ParseError) a -> QuoteT m a
+mapParseRun :: (MonadError Error m) => StateT IdentifierState (Except ParseError) a -> QuoteT m a
 -- we need to run the parser starting from our current next unique, then throw away the rest of the
 -- parser state and get back the new next unique
-mapParseRun run = MM.hoist (liftEither . runExcept) $ QuoteT $ StateT $ \nextU -> do
+mapParseRun run = MM.hoist (liftEither . convertError . runExcept) $ QuoteT $ StateT $ \nextU -> do
     (p, (_, _, u)) <- runStateT run (identifierStateFrom nextU)
     pure (p, u)
 
 -- | Parse a PLC program. The resulting program will have fresh names. The underlying monad must be capable
 -- of handling any parse errors.
-parseProgram :: (MonadError ParseError m) => BSL.ByteString -> QuoteT m (Program TyName Name AlexPosn)
+parseProgram :: (MonadError Error m) => BSL.ByteString -> QuoteT m (Program TyName Name AlexPosn)
 parseProgram str = mapParseRun (parseST str)
 
 -- | Parse a PLC term. The resulting program will have fresh names. The underlying monad must be capable
 -- of handling any parse errors.
-parseTerm :: (MonadError ParseError m) => BSL.ByteString -> QuoteT m (Term TyName Name AlexPosn)
+parseTerm :: (MonadError Error m) => BSL.ByteString -> QuoteT m (Term TyName Name AlexPosn)
 parseTerm str = mapParseRun (parseTermST str)
 
 -- | Parse a PLC type. The resulting program will have fresh names. The underlying monad must be capable
 -- of handling any parse errors.
-parseType :: (MonadError ParseError m) => BSL.ByteString -> QuoteT m (Type TyName AlexPosn)
+parseType :: (MonadError Error m) => BSL.ByteString -> QuoteT m (Type TyName AlexPosn)
 parseType str = mapParseRun (parseTypeST str)
+
+-- | Annotate a PLC program, so that all names are annotated with their types/kinds.
+annotateProgram :: (MonadError Error m) => Program TyName Name AlexPosn -> QuoteT m (Program TyNameWithKind NameWithType AlexPosn)
+annotateProgram (Program a v t) = Program a v <$> annotateTerm t
+
+-- | Annotate a PLC term, so that all names are annotated with their types/kinds.
+annotateTerm :: (MonadError Error m) => Term TyName Name AlexPosn -> QuoteT m (Term TyNameWithKind NameWithType AlexPosn)
+annotateTerm t = do
+  (ts, t') <- (lift . liftEither . convertError) (annotateTermST t)
+  updateMaxU ts
+  pure t'
+      where
+          updateMaxU :: (Monad m) => TypeState a -> QuoteT m ()
+          updateMaxU (TypeState _ tys) = do
+              nextU <- get
+              let tsMaxU = maybe 0 (fst . fst) (IM.maxViewWithKey tys)
+              let maxU = unUnique nextU - 1
+              put $ Unique $ max maxU tsMaxU
+
+-- | Typecheck a PLC program.
+typecheckProgram :: (MonadError Error m) => Natural -> Program TyNameWithKind NameWithType AlexPosn -> QuoteT m (Type TyNameWithKind ())
+typecheckProgram n (Program _ _ t) = typecheckTerm n t
+
+-- | Typecheck a PLC term.
+typecheckTerm :: (MonadError Error m) => Natural -> Term TyNameWithKind NameWithType AlexPosn -> QuoteT m (Type TyNameWithKind ())
+typecheckTerm n t = do
+  nextU <- get
+  let maxU = unUnique nextU - 1
+  (lift . liftEither . convertError) (runTypeCheckM maxU n (typeOf t))

--- a/language-plutus-core/src/Language/PlutusCore/TH.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TH.hs
@@ -9,8 +9,9 @@ module Language.PlutusCore.TH (plcTerm, plcType, plcProgram) where
 import           Language.Haskell.TH        hiding (Name, Type)
 import           Language.Haskell.TH.Quote
 
+import           Language.PlutusCore.Error
 import           Language.PlutusCore.Name
-import           Language.PlutusCore.Parser (ParseError)
+import           Language.PlutusCore.PrettyCfg
 import           Language.PlutusCore.Quote
 import           Language.PlutusCore.Subst
 import           Language.PlutusCore.Type
@@ -91,9 +92,9 @@ metavarSubstTerm t tyMetavars termMetavars = substTerm
                         t
 
 -- | Runs a 'QuoteT' in the 'Q' context. Note that this uses 'runQuoteT', so does note preserve freshness.
-eval :: QuoteT (Except ParseError) a -> Q a
+eval :: QuoteT (Except Error) a -> Q a
 eval c = case runExcept $ runQuoteT c of
-    Left e  -> fail $ show e
+    Left e  -> fail $ show $ prettyCfgText e
     Right p -> pure p
 
 unsafeDropErrors :: Except e a -> a


### PR DESCRIPTION
@vmchale this is what I was thinking.

This adds a `Quote` interface to annotating and typechecking. `QuoteT` already has a counter for the next `Unique` to use, so all we need to do is:
- Update the counter after we run `annotate` to the maximum of the previous value and the one output by `annotate`.
    - I'm basing this on what is done for `programType`.
    - It seems suspicious to me that `annotate` doesn't take a previous max unique value.
- Pass in our counter to `runTypeCheckM`.

I haven't replaced any of the other uses, although I think possibly they may prefer to use this in the long run if we keep using `QuoteT` as our primary "term construction monad".

As a side effect, this will let you typecheck your quasiquotes, which is nice.