### PR TITLE
Give Error a type param, allow arbitrary other errors

### DIFF
--- a/language-plutus-core/run-ck/Main.hs
+++ b/language-plutus-core/run-ck/Main.hs
@@ -9,7 +9,7 @@ import           Data.Text.Encoding   (encodeUtf8)
 import qualified Data.Text.IO         as Text
 
 -- | Parse a program and run it using the CK machine.
-parseRunCk :: BSL.ByteString -> Either ParseError CkEvalResult
+parseRunCk :: BSL.ByteString -> Either (ParseError AlexPosn) CkEvalResult
 parseRunCk = fmap (runCk . void) . parseScoped
 
 -- | Parse a program, run it and prettyprint the result.

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -149,7 +149,7 @@ fileTypeCfg :: Configuration -> FilePath -> IO T.Text
 fileTypeCfg cfg = fmap (either (renderCfg cfg) id . printType) . BSL.readFile
 
 -- | Print the type of a program contained in a 'ByteString'
-printType :: BSL.ByteString -> Either Error T.Text
+printType :: BSL.ByteString -> Either (Error AlexPosn) T.Text
 printType = collectErrors . fmap (convertError . typeErr <=< convertError . annotateST) . parseScoped
 
 typeErr :: (TypeState a, Program TyNameWithKind NameWithType a) -> Either (TypeError a) T.Text
@@ -157,7 +157,7 @@ typeErr = fmap prettyCfgText . uncurry (programType 10000)
 
 -- | Parse and rewrite so that names are globally unique, not just unique within
 -- their scope.
-parseScoped :: BSL.ByteString -> Either ParseError (Program TyName Name AlexPosn)
+parseScoped :: BSL.ByteString -> Either (ParseError AlexPosn) (Program TyName Name AlexPosn)
 parseScoped str = fmap (\(p, s) -> rename s p) $ runExcept $ runStateT (parseST str) emptyIdentifierState
 
 programType :: Natural -- ^ Gas provided to typechecker
@@ -167,8 +167,8 @@ programType :: Natural -- ^ Gas provided to typechecker
 programType n (TypeState _ tys) (Program _ _ t) = runTypeCheckM i n $ typeOf t
     where i = maybe 0 (fst . fst) (IM.maxViewWithKey tys)
 
-formatDoc :: BSL.ByteString -> Either ParseError (Doc a)
+formatDoc :: BSL.ByteString -> Either (ParseError AlexPosn) (Doc a)
 formatDoc = fmap (prettyCfg defaultCfg) . parse
 
-format :: Configuration -> BSL.ByteString -> Either ParseError T.Text
+format :: Configuration -> BSL.ByteString -> Either (ParseError AlexPosn) T.Text
 format cfg = fmap (render . prettyCfg cfg) . parseScoped

--- a/language-plutus-core/src/Language/PlutusCore/Lexer.x
+++ b/language-plutus-core/src/Language/PlutusCore/Lexer.x
@@ -124,6 +124,9 @@ deriving instance Lift AlexPosn
 instance Pretty (AlexPosn) where
     pretty (AlexPn _ line col) = pretty line <> ":" <> pretty col
 
+instance PrettyCfg (AlexPosn) where
+    prettyCfg _ (AlexPn _ line col) = pretty line <> ":" <> pretty col
+
 handleChar :: Word8 -> Word8
 handleChar x
     | x >= 48 && x <= 57 = x - 48 -- hexits 0-9
@@ -215,21 +218,21 @@ alexEOF :: Alex (Token AlexPosn)
 alexEOF = EOF . alex_pos <$> get
 
 -- | An error encountered during parsing.
-data ParseError = LexErr String
-                | Unexpected (Token AlexPosn)
-                | Overflow AlexPosn Natural Integer
-                deriving (Show, Eq, Generic, NFData)
+data ParseError a = LexErr String
+                  | Unexpected (Token a)
+                  | Overflow a Natural Integer
+                  deriving (Show, Eq, Generic, NFData)
 
-instance PrettyCfg ParseError where
+instance (PrettyCfg a) => PrettyCfg (ParseError a) where
     prettyCfg _ (LexErr s)         = "Lexical error:" <+> Text (length s) (T.pack s)
-    prettyCfg cfg (Unexpected t)   = "Unexpected" <+> squotes (prettyCfg cfg t) <+> "at" <+> pretty (loc t)
-    prettyCfg _ (Overflow pos _ _) = "Integer overflow at" <+> pretty pos <> "."
+    prettyCfg cfg (Unexpected t)   = "Unexpected" <+> squotes (prettyCfg cfg t) <+> "at" <+> prettyCfg cfg (loc t)
+    prettyCfg cfg (Overflow pos _ _) = "Integer overflow at" <+> prettyCfg cfg pos <> "."
 
-liftError :: Either String a -> Either ParseError a
+liftError :: Either String a -> Either (ParseError b) a
 liftError(Left s)  = Left $ LexErr s
 liftError(Right a) = Right $ a
 
-runAlexST :: ByteString.ByteString -> Alex a -> IdentifierState -> Either ParseError (IdentifierState, a)
+runAlexST :: ByteString.ByteString -> Alex a -> IdentifierState -> Either (ParseError AlexPosn) (IdentifierState, a)
 runAlexST input (Alex f) initial = liftError $ first alex_ust <$>
     f (AlexState { alex_pos = alexStartPos
                  , alex_bpos = 0
@@ -239,9 +242,9 @@ runAlexST input (Alex f) initial = liftError $ first alex_ust <$>
                  , alex_scd = 0
                  })
 
-runAlexST' :: forall a. ByteString.ByteString -> Alex a -> StateT IdentifierState (Except ParseError) a
+runAlexST' :: forall a. ByteString.ByteString -> Alex a -> StateT IdentifierState (Except (ParseError AlexPosn)) a
 runAlexST' input al = StateT $ \is -> let
-        run :: Either ParseError (a, IdentifierState)
+        run :: Either (ParseError AlexPosn) (a, IdentifierState)
         run = case runAlexST input al is of
             Left e -> Left e
             Right (s, a) -> Right (a, s)

--- a/language-plutus-core/src/Language/PlutusCore/Normalize.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Normalize.hs
@@ -10,6 +10,7 @@ module Language.PlutusCore.Normalize ( check
 
 import           Data.Functor.Foldable
 import           Data.Functor.Foldable.Monadic
+import           Language.PlutusCore.PrettyCfg
 import           Language.PlutusCore.Type
 import           PlutusPrelude
 
@@ -17,9 +18,9 @@ data NormalizationError a = BadType a
                           | BadTerm a
                           deriving (Generic, NFData)
 
-instance Pretty a => Pretty (NormalizationError a) where
-    pretty (BadType l) = "Malformed type at" <+> pretty l
-    pretty (BadTerm l) = "Malformed term at" <+> pretty l
+instance PrettyCfg a => PrettyCfg (NormalizationError a) where
+    prettyCfg cfg (BadType l) = "Malformed type at" <+> prettyCfg cfg l
+    prettyCfg cfg (BadTerm l) = "Malformed term at" <+> prettyCfg cfg l
 
 check :: Program tyname name a -> Maybe (NormalizationError a)
 check = go . preCheck where

--- a/language-plutus-core/src/Language/PlutusCore/Parser.y
+++ b/language-plutus-core/src/Language/PlutusCore/Parser.y
@@ -147,13 +147,13 @@ handleInteger x sz i = if isOverflow
     where isOverflow = i < (-k) || i > (k - 1)
           k = 8 ^ sz `div` 2
 
-parseST :: BSL.ByteString -> StateT IdentifierState (Except ParseError) (Program TyName Name AlexPosn)
+parseST :: BSL.ByteString -> StateT IdentifierState (Except (ParseError AlexPosn)) (Program TyName Name AlexPosn)
 parseST str =  runAlexST' str (runExceptT parsePlutusCoreProgram) >>= liftEither
 
-parseTermST :: BSL.ByteString -> StateT IdentifierState (Except ParseError) (Term TyName Name AlexPosn)
+parseTermST :: BSL.ByteString -> StateT IdentifierState (Except (ParseError AlexPosn)) (Term TyName Name AlexPosn)
 parseTermST str = runAlexST' str (runExceptT parsePlutusCoreTerm) >>= liftEither
 
-parseTypeST :: BSL.ByteString -> StateT IdentifierState (Except ParseError) (Type TyName AlexPosn)
+parseTypeST :: BSL.ByteString -> StateT IdentifierState (Except (ParseError AlexPosn)) (Type TyName AlexPosn)
 parseTypeST str = runAlexST' str (runExceptT parsePlutusCoreType) >>= liftEither
 
 -- | Parse a 'ByteString' containing a Plutus Core program, returning a 'ParseError' if syntactically invalid.
@@ -161,10 +161,10 @@ parseTypeST str = runAlexST' str (runExceptT parsePlutusCoreType) >>= liftEither
 -- >>> :set -XOverloadedStrings
 -- >>> parse "(program 0.1.0 [(con addInteger) x y])"
 -- Right (Program (AlexPn 1 1 2) (Version (AlexPn 9 1 10) 0 1 0) (Apply (AlexPn 15 1 16) (Apply (AlexPn 15 1 16) (Constant (AlexPn 17 1 18) (BuiltinName (AlexPn 21 1 22) AddInteger)) (Var (AlexPn 33 1 34) (Name {nameAttribute = AlexPn 33 1 34, nameString = "x", nameUnique = Unique {unUnique = 0}}))) (Var (AlexPn 35 1 36) (Name {nameAttribute = AlexPn 35 1 36, nameString = "y", nameUnique = Unique {unUnique = 1}}))))
-parse :: BSL.ByteString -> Either ParseError (Program TyName Name AlexPosn)
+parse :: BSL.ByteString -> Either (ParseError AlexPosn) (Program TyName Name AlexPosn)
 parse str = fmap fst $ runExcept $ runStateT (parseST str) emptyIdentifierState
 
-type Parse = ExceptT ParseError Alex
+type Parse = ExceptT (ParseError AlexPosn) Alex
 
 parseError :: Token AlexPosn -> Parse b
 parseError = throwError . Unexpected

--- a/language-plutus-core/src/Language/PlutusCore/Renamer.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Renamer.hs
@@ -65,9 +65,9 @@ data RenameError a = UnboundVar (Name a)
                    | UnboundTyVar (TyName a)
                    deriving (Generic, NFData)
 
-instance PrettyCfg (RenameError AlexPosn) where
-    prettyCfg cfg (UnboundVar n@(Name loc _ _)) = "Error at" <+> pretty loc <> ". Variable" <+> prettyCfg cfg n <+> "is not in scope."
-    prettyCfg cfg (UnboundTyVar n@(TyName (Name loc _ _))) = "Error at" <+> pretty loc <> ". Type variable" <+> prettyCfg cfg n <+> "is not in scope."
+instance (PrettyCfg a) => PrettyCfg (RenameError a) where
+    prettyCfg cfg (UnboundVar n@(Name loc _ _)) = "Error at" <+> prettyCfg cfg loc <> ". Variable" <+> prettyCfg cfg n <+> "is not in scope."
+    prettyCfg cfg (UnboundTyVar n@(TyName (Name loc _ _))) = "Error at" <+> prettyCfg cfg loc <> ". Type variable" <+> prettyCfg cfg n <+> "is not in scope."
 
 -- | Annotate a program with type/kind information at all bound variables,
 -- failing if we encounter a free variable.

--- a/language-plutus-core/src/Language/PlutusCore/TH.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TH.hs
@@ -92,7 +92,7 @@ metavarSubstTerm t tyMetavars termMetavars = substTerm
                         t
 
 -- | Runs a 'QuoteT' in the 'Q' context. Note that this uses 'runQuoteT', so does note preserve freshness.
-eval :: QuoteT (Except Error) a -> Q a
+eval :: (PrettyCfg b) => QuoteT (Except (Error b)) a -> Q a
 eval c = case runExcept $ runQuoteT c of
     Left e  -> fail $ show $ prettyCfgText e
     Right p -> pure p

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -38,10 +38,10 @@ data TypeError a = InternalError -- ^ This is thrown if builtin lookup fails
                  | OutOfGas
                  deriving (Generic, NFData)
 
-instance Pretty a => PrettyCfg (TypeError a) where
+instance (PrettyCfg a) => PrettyCfg (TypeError a) where
     prettyCfg _ InternalError               = "Internal error."
-    prettyCfg cfg (KindMismatch x ty k k')  = "Kind mismatch at" <+> pretty x <+> "in type" <+> squotes (prettyCfg cfg ty) <> ". Expected kind" <+> squotes (pretty k) <+> ", found kind" <+> squotes (pretty k')
-    prettyCfg cfg (TypeMismatch x t ty ty') = "Type mismatch at" <+> pretty x <+> "in term" <+> squotes (prettyCfg cfg t) <> ". Expected type" <+> squotes (prettyCfg cfg ty) <+> ", found type" <+> squotes (prettyCfg cfg ty')
+    prettyCfg cfg (KindMismatch x ty k k')  = "Kind mismatch at" <+> prettyCfg cfg x <+> "in type" <+> squotes (prettyCfg cfg ty) <> ". Expected kind" <+> squotes (pretty k) <+> ", found kind" <+> squotes (pretty k')
+    prettyCfg cfg (TypeMismatch x t ty ty') = "Type mismatch at" <+> prettyCfg cfg x <+> "in term" <+> squotes (prettyCfg cfg t) <> ". Expected type" <+> squotes (prettyCfg cfg ty) <+> ", found type" <+> squotes (prettyCfg cfg ty')
     prettyCfg _ OutOfGas                    = "Type checker ran out of gas."
 
 isType :: Kind a -> Bool


### PR DESCRIPTION
Without this, we can't do annotating and typechecking with terms that aren't annotated with `AlexPosn`s (i.e. with synthetic terms), because we need to produce `Error`s which are locked to containing `AlexPosn`s. The end goal is the generalization of the functions in `Quote`.

I also added an `OtherError` constructor for things that haven't merited their own branch yet.

This change does mean that the errors won't have informative locations, but that's simply true for generated 
terms. (We could also add some explanatory text, but that can be a separate change).