### PR TITLE
Filter out .ghc.environment files

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -41,6 +41,7 @@ let
       lib.hasSuffix "~" baseName ||
       builtins.match "^\\.sw[a-z]$" baseName != null ||
       builtins.match "^\\..*\\.sw[a-z]$" baseName != null ||
+      builtins.match "^\\.ghc\\.environment\\..*$" baseName != null ||
       baseName == "dist" || baseName == "dist-newstyle" ||
       baseName == "cabal.project.local" ||
       lib.hasSuffix ".nix" baseName ||


### PR DESCRIPTION
This is IMO a horrifying misfeature which breaks nix builds in subtle ways. FYI @disassembler you might want to port this to Cardano in case anybody starts using `new-build` and wonders why everything is broken.