### PR TITLE
Improve dependencies relating to `Quote`

### DIFF
--- a/language-plutus-core/plutus-exe/Main.hs
+++ b/language-plutus-core/plutus-exe/Main.hs
@@ -64,9 +64,9 @@ parseRunCk = fmap (CK.runCk . void) . PC.parseScoped
 -- | Parse a program and typecheck it.
 parseTypecheck :: BSL.ByteString -> Either (PC.Error PC.AlexPosn) (PC.Type PC.TyNameWithKind ())
 parseTypecheck bs = runExcept $ PC.runQuoteT $ do
-    parsed <- PC.parseProgram bs
-    annotated <- PC.annotateProgram parsed
-    PC.typecheckProgram 1000 annotated
+    parsed <- PC.parseProgramQ bs
+    annotated <- PC.annotateProgramQ parsed
+    PC.typecheckProgramQ 1000 annotated
 
 main :: IO ()
 main = do

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -8,6 +8,9 @@ module Language.PlutusCore
     , parseTermST
     , parseTypeST
     , parseScoped
+    , parseProgramQ
+    , parseTermQ
+    , parseTypeQ
     -- * Pretty-printing
     , prettyCfgText
     , prettyCfgString
@@ -40,6 +43,8 @@ module Language.PlutusCore
     -- * Processing
     , annotate
     , annotateST
+    , annotateProgramQ
+    , annotateTermQ
     , RenameError (..)
     , TyNameWithKind (..)
     , NameWithType (..)
@@ -52,6 +57,8 @@ module Language.PlutusCore
     -- * Type synthesis
     , typeOf
     , kindOf
+    , typecheckProgramQ
+    , typecheckTermQ
     , runTypeCheckM
     , programType
     , fileType

--- a/language-plutus-core/src/Language/PlutusCore/Quote.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Quote.hs
@@ -10,35 +10,22 @@ module Language.PlutusCore.Quote (
             , freshUnique
             , freshName
             , freshTyName
-            , parseProgram
-            , parseTerm
-            , parseType
-            , annotateProgram
-            , annotateTerm
-            , typecheckProgram
-            , typecheckTerm
             , QuoteT
             , Quote
             , MonadQuote
+            , FreshState
             , liftQuote
             , convertErrors
             ) where
 
 import           Control.Monad.Except
-import           Control.Monad.Morph               as MM
+import           Control.Monad.Morph      as MM
 import           Control.Monad.Reader
 import           Control.Monad.State
-import qualified Data.ByteString.Lazy              as BSL
+import qualified Data.ByteString.Lazy     as BSL
 import           Data.Functor.Identity
-import qualified Data.IntMap                       as IM
-import           Language.PlutusCore.Lexer         (AlexPosn)
 
-import           Language.PlutusCore.Error
 import           Language.PlutusCore.Name
-import           Language.PlutusCore.Parser        (ParseError, parseST, parseTermST, parseTypeST)
-import           Language.PlutusCore.Renamer
-import           Language.PlutusCore.Type
-import           Language.PlutusCore.TypeSynthesis
 import           PlutusPrelude
 
 -- | The state contains the "next" 'Unique' that should be used for a name
@@ -50,7 +37,6 @@ emptyFreshState = Unique 0
 -- | The "quotation" monad transformer. Within this monad you can do safe construction of PLC terms using quasiquotation,
 -- fresh-name generation, and parsing.
 newtype QuoteT m a = QuoteT { unQuoteT :: StateT FreshState m a }
-    -- the MonadState constraint is handy, but it's useless outside since we don't export the state type
     deriving (Functor, Applicative, Monad, MonadTrans, MM.MFunctor, MonadState FreshState, MonadError e, MonadReader r)
 
 -- | A monad that allows lifting of quoted expressions.
@@ -103,55 +89,3 @@ freshName ann str = Name ann str <$> freshUnique
 -- | Get a fresh 'TyName', given the annotation an the name.
 freshTyName :: (Monad m) => a -> BSL.ByteString -> QuoteT m (TyName a)
 freshTyName = fmap TyName .* freshName
-
-mapParseRun :: (MonadError (Error a) m, MonadQuote m) => StateT IdentifierState (Except (ParseError a)) b -> m b
--- we need to run the parser starting from our current next unique, then throw away the rest of the
--- parser state and get back the new next unique
-mapParseRun run = convertErrors asError $ do
-    nextU <- liftQuote get
-    (p, (_, _, u)) <- liftEither $ runExcept $ runStateT run (identifierStateFrom nextU)
-    liftQuote $ put u
-    pure p
-
--- | Parse a PLC program. The resulting program will have fresh names. The underlying monad must be capable
--- of handling any parse errors.
-parseProgram :: (MonadError (Error AlexPosn) m, MonadQuote m) => BSL.ByteString -> m (Program TyName Name AlexPosn)
-parseProgram str = mapParseRun (parseST str)
-
--- | Parse a PLC term. The resulting program will have fresh names. The underlying monad must be capable
--- of handling any parse errors.
-parseTerm :: (MonadError (Error AlexPosn) m, MonadQuote m) => BSL.ByteString -> m (Term TyName Name AlexPosn)
-parseTerm str = mapParseRun (parseTermST str)
-
--- | Parse a PLC type. The resulting program will have fresh names. The underlying monad must be capable
--- of handling any parse errors.
-parseType :: (MonadError (Error AlexPosn) m, MonadQuote m) => BSL.ByteString -> m (Type TyName AlexPosn)
-parseType str = mapParseRun (parseTypeST str)
-
--- | Annotate a PLC program, so that all names are annotated with their types/kinds.
-annotateProgram :: (MonadError (Error a) m, MonadQuote m) => Program TyName Name a -> m (Program TyNameWithKind NameWithType a)
-annotateProgram (Program a v t) = Program a v <$> annotateTerm t
-
--- | Annotate a PLC term, so that all names are annotated with their types/kinds.
-annotateTerm :: forall m a . (MonadError (Error a) m, MonadQuote m) => Term TyName Name a -> m (Term TyNameWithKind NameWithType a)
-annotateTerm t = convertErrors asError $ do
-    (ts, t') <- liftEither $ annotateTermST t
-    updateMaxU ts
-    pure t'
-        where
-            updateMaxU (TypeState _ tys) = do
-                nextU <- liftQuote get
-                let tsMaxU = maybe 0 (fst . fst) (IM.maxViewWithKey tys)
-                let maxU = unUnique nextU - 1
-                liftQuote $ put $ Unique $ max maxU tsMaxU
-
--- | Typecheck a PLC program.
-typecheckProgram :: (MonadError (Error a) m, MonadQuote m) => Natural -> Program TyNameWithKind NameWithType a -> m (Type TyNameWithKind ())
-typecheckProgram n (Program _ _ t) = typecheckTerm n t
-
--- | Typecheck a PLC term.
-typecheckTerm :: (MonadError (Error a) m, MonadQuote m) => Natural -> Term TyNameWithKind NameWithType a -> m (Type TyNameWithKind ())
-typecheckTerm n t = convertErrors asError $ do
-    nextU <- liftQuote get
-    let maxU = unUnique nextU - 1
-    liftEither $ runTypeCheckM maxU n (typeOf t)

--- a/language-plutus-core/src/Language/PlutusCore/Renamer.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Renamer.hs
@@ -1,26 +1,23 @@
-{-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE FlexibleInstances  #-}
-{-# LANGUAGE OverloadedStrings  #-}
 
 module Language.PlutusCore.Renamer ( rename
                                    , annotate
                                    , annotateST
                                    , annotateTermST
-                                   , NameWithType (..)
-                                   , RenamedType
-                                   , RenamedTerm
-                                   , TyNameWithKind (..)
-                                   , RenameError (..)
+                                   , annotateProgramQ
+                                   , annotateTermQ
                                    , TypeState (..)
+                                   , RenameError (..)
                                    ) where
 
 import           Control.Monad.Except
 import           Control.Monad.State.Lazy
-import qualified Data.IntMap                   as IM
+import qualified Data.IntMap               as IM
+import           Language.PlutusCore.Error
 import           Language.PlutusCore.Name
-import           Language.PlutusCore.PrettyCfg
+import           Language.PlutusCore.Quote
 import           Language.PlutusCore.Type
 import           Lens.Micro
 import           PlutusPrelude
@@ -42,32 +39,22 @@ instance Monoid (TypeState a) where
 
 type TypeM a = StateT (TypeState a) (Either (RenameError a))
 
-type RenamedTerm a = Term TyNameWithKind NameWithType a
-newtype NameWithType a = NameWithType (Name (a, RenamedType a))
-    deriving (Functor, Generic)
-    deriving newtype NFData
-type RenamedType a = Type TyNameWithKind a
-newtype TyNameWithKind a = TyNameWithKind { unTyNameWithKind :: TyName (a, Kind a) }
-    deriving (Eq, Functor, Generic)
-    deriving newtype NFData
+-- | Annotate a PLC program, so that all names are annotated with their types/kinds.
+annotateProgramQ :: (MonadError (Error a) m, MonadQuote m) => Program TyName Name a -> m (Program TyNameWithKind NameWithType a)
+annotateProgramQ (Program a v t) = Program a v <$> annotateTermQ t
 
-instance PrettyCfg (TyNameWithKind a) where
-    prettyCfg cfg@(Configuration _ True) (TyNameWithKind (TyName tn@(Name (_, k) _ _))) = parens (prettyCfg cfg tn <+> ":" <+> pretty k)
-    prettyCfg cfg@(Configuration _ False) (TyNameWithKind tn) = prettyCfg cfg tn
-
-instance PrettyCfg (NameWithType a) where
-    prettyCfg cfg@(Configuration _ True) (NameWithType n@(Name (_, ty) _ _)) = parens (prettyCfg cfg n <+> ":" <+> prettyCfg cfg ty)
-    prettyCfg cfg@(Configuration _ False) (NameWithType n) = prettyCfg cfg n
-
--- | A 'RenameError' is thrown when a free variable is encountered during
--- rewriting.
-data RenameError a = UnboundVar (Name a)
-                   | UnboundTyVar (TyName a)
-                   deriving (Generic, NFData)
-
-instance (PrettyCfg a) => PrettyCfg (RenameError a) where
-    prettyCfg cfg (UnboundVar n@(Name loc _ _)) = "Error at" <+> prettyCfg cfg loc <> ". Variable" <+> prettyCfg cfg n <+> "is not in scope."
-    prettyCfg cfg (UnboundTyVar n@(TyName (Name loc _ _))) = "Error at" <+> prettyCfg cfg loc <> ". Type variable" <+> prettyCfg cfg n <+> "is not in scope."
+-- | Annotate a PLC term, so that all names are annotated with their types/kinds.
+annotateTermQ :: forall m a . (MonadError (Error a) m, MonadQuote m) => Term TyName Name a -> m (Term TyNameWithKind NameWithType a)
+annotateTermQ t = convertErrors asError $ do
+    (ts, t') <- liftEither $ annotateTermST t
+    updateMaxU ts
+    pure t'
+        where
+            updateMaxU (TypeState _ tys) = do
+                nextU <- liftQuote get
+                let tsMaxU = maybe 0 (fst . fst) (IM.maxViewWithKey tys)
+                let maxU = unUnique nextU - 1
+                liftQuote $ put $ Unique $ max maxU tsMaxU
 
 -- | Annotate a program with type/kind information at all bound variables,
 -- failing if we encounter a free variable.

--- a/language-plutus-core/src/Language/PlutusCore/TH.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TH.hs
@@ -11,6 +11,7 @@ import           Language.Haskell.TH.Quote
 
 import           Language.PlutusCore.Error
 import           Language.PlutusCore.Name
+import           Language.PlutusCore.Parser
 import           Language.PlutusCore.PrettyCfg
 import           Language.PlutusCore.Quote
 import           Language.PlutusCore.Subst
@@ -120,7 +121,7 @@ Finally, we need to drop the lexer position annotations, since they're not terri
 
 compileTerm :: String -> Q Exp
 compileTerm s = do
-    compileTimeT <- eval $ parseTerm $ strToBs s
+    compileTimeT <- eval $ parseTermQ $ strToBs s
     let
         tyMetavars = metavarMapType (ftvTerm compileTimeT)
         termMetavars = metavarMapTerm (fvTerm compileTimeT)
@@ -129,14 +130,14 @@ compileTerm s = do
             quoted :: Quote (Term TyName Name ())
             quoted = do
                 -- See note [Parsing and TH stages]
-                runtimeT <- (fmap void . MM.hoist (Identity . unsafeDropErrors) . parseTerm . strToBs) s
+                runtimeT <- (fmap void . MM.hoist (Identity . unsafeDropErrors) . parseTermQ . strToBs) s
                 metavarSubstTerm runtimeT <$> $(tyMetavars) <*> $(termMetavars)
         in quoted
      |]
 
 compileType :: String -> Q Exp
 compileType s = do
-    compileTimeTy <- eval $ parseType $ strToBs s
+    compileTimeTy <- eval $ parseTypeQ $ strToBs s
     let
         tyMetavars = metavarMapType (ftvTy compileTimeTy)
     [|
@@ -144,14 +145,14 @@ compileType s = do
             quoted :: Quote (Type TyName ())
             quoted = do
                 -- See note [Parsing and TH stages]
-                runtimeTy <- (fmap void . MM.hoist (Identity . unsafeDropErrors) . parseType . strToBs) s
+                runtimeTy <- (fmap void . MM.hoist (Identity . unsafeDropErrors) . parseTypeQ . strToBs) s
                 metavarSubstType runtimeTy <$> $(tyMetavars)
           in quoted
       |]
 
 compileProgram :: String -> Q Exp
 compileProgram s = do
-    (Program _ _ compileTimeT) <- eval $ parseProgram $ strToBs s
+    (Program _ _ compileTimeT) <- eval $ parseProgramQ $ strToBs s
     let
         tyMetavars = metavarMapType (ftvTerm compileTimeT)
         termMetavars= metavarMapTerm (fvTerm compileTimeT)
@@ -160,7 +161,7 @@ compileProgram s = do
             quoted :: Quote (Program TyName Name ())
             quoted = do
                 -- See note [Parsing and TH stages]
-                (Program a v runtimeT) <- (fmap void . MM.hoist (Identity . unsafeDropErrors) . parseProgram . strToBs) s
+                (Program a v runtimeT) <- (fmap void . MM.hoist (Identity . unsafeDropErrors) . parseProgramQ . strToBs) s
                 Program a v . metavarSubstTerm runtimeT <$> $(tyMetavars) <*> $(termMetavars)
         in quoted
      |]

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -1,15 +1,15 @@
-{-# LANGUAGE DeriveAnyClass      #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE MonadComprehensions #-}
 {-# LANGUAGE OverloadedStrings   #-}
 
-
 module Language.PlutusCore.TypeSynthesis ( kindOf
                                          , typeOf
                                          , runTypeCheckM
-                                         , TypeError (..)
+                                         , typecheckProgramQ
+                                         , typecheckTermQ
                                          , TypeCheckM
                                          , BuiltinTable (..)
+                                         , TypeError (..)
                                          ) where
 
 import           Control.Monad.Except
@@ -18,10 +18,10 @@ import           Control.Monad.State.Class
 import           Control.Monad.Trans.State      hiding (get, modify)
 import           Data.Functor.Foldable
 import qualified Data.Map                       as M
+import           Language.PlutusCore.Error
 import           Language.PlutusCore.Lexer.Type
 import           Language.PlutusCore.Name
-import           Language.PlutusCore.PrettyCfg
-import           Language.PlutusCore.Renamer
+import           Language.PlutusCore.Quote
 import           Language.PlutusCore.Type
 import           PlutusPrelude
 
@@ -32,18 +32,6 @@ data BuiltinTable = BuiltinTable (M.Map TypeBuiltin (Kind ())) (M.Map BuiltinNam
 -- | The type checking monad contains the 'BuiltinTable' and it lets us throw
 -- 'TypeError's.
 type TypeCheckM a = StateT Natural (ReaderT BuiltinTable (Either (TypeError a)))
-
-data TypeError a = InternalError -- ^ This is thrown if builtin lookup fails
-                 | KindMismatch a (Type TyNameWithKind ()) (Kind ()) (Kind ())
-                 | TypeMismatch a (Term TyNameWithKind NameWithType ()) (Type TyNameWithKind ()) (Type TyNameWithKind ())
-                 | OutOfGas
-                 deriving (Generic, NFData)
-
-instance (PrettyCfg a) => PrettyCfg (TypeError a) where
-    prettyCfg _ InternalError               = "Internal error."
-    prettyCfg cfg (KindMismatch x ty k k')  = "Kind mismatch at" <+> prettyCfg cfg x <+> "in type" <+> squotes (prettyCfg cfg ty) <> ". Expected kind" <+> squotes (pretty k) <+> ", found kind" <+> squotes (pretty k')
-    prettyCfg cfg (TypeMismatch x t ty ty') = "Type mismatch at" <+> prettyCfg cfg x <+> "in term" <> hardline <> indent 2 (squotes (prettyCfg cfg t)) <> "." <> hardline <> "Expected type" <> hardline <> indent 2 (squotes (prettyCfg cfg ty)) <> "," <> hardline <> "found type" <> hardline <> indent 2 (squotes (prettyCfg cfg ty'))
-    prettyCfg _ OutOfGas                    = "Type checker ran out of gas."
 
 isType :: Kind a -> Bool
 isType Type{} = True
@@ -112,6 +100,17 @@ defaultTable = do
         termTable = f intTypes is <> f intRelTypes irs <> f [TxHash, EqByteString] [txHash, bsRelType]
 
     pure $ BuiltinTable tyTable termTable
+
+-- | Typecheck a PLC program.
+typecheckProgramQ :: (MonadError (Error a) m, MonadQuote m) => Natural -> Program TyNameWithKind NameWithType a -> m (Type TyNameWithKind ())
+typecheckProgramQ n (Program _ _ t) = typecheckTermQ n t
+
+-- | Typecheck a PLC term.
+typecheckTermQ :: (MonadError (Error a) m, MonadQuote m) => Natural -> Term TyNameWithKind NameWithType a -> m (Type TyNameWithKind ())
+typecheckTermQ n t = convertErrors asError $ do
+    nextU <- liftQuote get
+    let maxU = unUnique nextU - 1
+    liftEither $ runTypeCheckM maxU n (typeOf t)
 
 -- | Run the type checker with a default context.
 runTypeCheckM :: Int -- ^ Largest @Unique@ in scope so far. This is used to allow us to generate globally unique names during type checking.


### PR DESCRIPTION
As noticed on Slack, it's annoying that `Quote` depends on other stuff so you get module cycles when using it. I have attempted to fix this by moving the functions that do typechecking etc. in `Quote` into the respective modules. Annoyingly, this introduces more cycles due to the `Error` type, so I've moved the error definitions into `Error` (mostly), which is annoying but doesn't seem too bad.

Finally, to avoid confusion, I've suffixed the quote commands with Q for now.

(Man, not having cyclic imports is annoying...)