### PR TITLE
language-plutus-core: standardise interface a bit more

### DIFF
--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -186,6 +186,7 @@ test-suite language-plutus-core-test
         text -any,
         prettyprinter -any,
         containers -any,
+        mtl -any,
         mmorph -any
 
     if flag(eventlog)

--- a/language-plutus-core/src/Language/PlutusCore/Error.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Error.hs
@@ -20,7 +20,7 @@ import qualified Data.Text                     as T
 
 data NormalizationError tyname name a = BadType a (Type tyname a) T.Text
                                       | BadTerm a (Term tyname name a) T.Text
-                                      deriving (Generic, NFData)
+                                      deriving (Show, Eq, Generic, NFData)
 
 instance (PrettyCfg (tyname a), PrettyCfg (name a), PrettyCfg a) => PrettyCfg (NormalizationError tyname name a) where
     prettyCfg cfg (BadType l ty expct) = "Malformed type at" <+> prettyCfg cfg l <> ". Type" <+> prettyCfg cfg ty <+> "is not a" <+> pretty expct <> "."
@@ -31,7 +31,7 @@ instance (PrettyCfg (tyname a), PrettyCfg (name a), PrettyCfg a) => PrettyCfg (N
 -- rewriting.
 data RenameError a = UnboundVar (Name a)
                    | UnboundTyVar (TyName a)
-                   deriving (Generic, NFData)
+                   deriving (Show, Eq, Generic, NFData)
 
 instance (PrettyCfg a) => PrettyCfg (RenameError a) where
     prettyCfg cfg (UnboundVar n@(Name loc _ _)) = "Error at" <+> prettyCfg cfg loc <> ". Variable" <+> prettyCfg cfg n <+> "is not in scope."
@@ -41,7 +41,7 @@ data TypeError a = InternalError -- ^ This is thrown if builtin lookup fails
                  | KindMismatch a (Type TyNameWithKind ()) (Kind ()) (Kind ())
                  | TypeMismatch a (Term TyNameWithKind NameWithType ()) (Type TyNameWithKind ()) (Type TyNameWithKind ())
                  | OutOfGas
-                 deriving (Generic, NFData)
+                 deriving (Show, Eq, Generic, NFData)
 
 instance (PrettyCfg a) => PrettyCfg (TypeError a) where
     prettyCfg _ InternalError               = "Internal error."
@@ -53,7 +53,7 @@ data Error a = ParseError (ParseError a)
              | RenameError (RenameError a)
              | TypeError (TypeError a)
              | NormalizationError (NormalizationError TyName Name a)
-             deriving (Generic, NFData)
+             deriving (Show, Eq, Generic, NFData)
 
 class IsError f where
 

--- a/language-plutus-core/src/Language/PlutusCore/Parser.y
+++ b/language-plutus-core/src/Language/PlutusCore/Parser.y
@@ -5,9 +5,9 @@
                                       , parseST
                                       , parseTermST
                                       , parseTypeST
-                                      , parseProgramQ
-                                      , parseTermQ
-                                      , parseTypeQ
+                                      , parseProgram
+                                      , parseTerm
+                                      , parseType
                                       , ParseError (..)
                                       ) where
 
@@ -171,18 +171,18 @@ mapParseRun run = convertErrors asError $ do
 
 -- | Parse a PLC program. The resulting program will have fresh names. The underlying monad must be capable
 -- of handling any parse errors.
-parseProgramQ :: (MonadError (Error AlexPosn) m, MonadQuote m) => BSL.ByteString -> m (Program TyName Name AlexPosn)
-parseProgramQ str = mapParseRun (parseST str)
+parseProgram :: (MonadError (Error AlexPosn) m, MonadQuote m) => BSL.ByteString -> m (Program TyName Name AlexPosn)
+parseProgram str = mapParseRun (parseST str)
 
 -- | Parse a PLC term. The resulting program will have fresh names. The underlying monad must be capable
 -- of handling any parse errors.
-parseTermQ :: (MonadError (Error AlexPosn) m, MonadQuote m) => BSL.ByteString -> m (Term TyName Name AlexPosn)
-parseTermQ str = mapParseRun (parseTermST str)
+parseTerm :: (MonadError (Error AlexPosn) m, MonadQuote m) => BSL.ByteString -> m (Term TyName Name AlexPosn)
+parseTerm str = mapParseRun (parseTermST str)
 
 -- | Parse a PLC type. The resulting program will have fresh names. The underlying monad must be capable
 -- of handling any parse errors.
-parseTypeQ :: (MonadError (Error AlexPosn) m, MonadQuote m) => BSL.ByteString -> m (Type TyName AlexPosn)
-parseTypeQ str = mapParseRun (parseTypeST str)
+parseType :: (MonadError (Error AlexPosn) m, MonadQuote m) => BSL.ByteString -> m (Type TyName AlexPosn)
+parseType str = mapParseRun (parseTypeST str)
 
 -- | Parse a 'ByteString' containing a Plutus Core program, returning a 'ParseError' if syntactically invalid.
 --

--- a/language-plutus-core/src/Language/PlutusCore/PrettyCfg.hs
+++ b/language-plutus-core/src/Language/PlutusCore/PrettyCfg.hs
@@ -27,6 +27,7 @@ class PrettyCfg a where
 
 instance PrettyCfg Bool
 instance PrettyCfg Integer
+instance PrettyCfg ()
 
 instance PrettyCfg a => PrettyCfg [a] where
     prettyCfg cfg = list . fmap (prettyCfg cfg)

--- a/language-plutus-core/src/Language/PlutusCore/Renamer.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Renamer.hs
@@ -42,15 +42,11 @@ annotateProgram (Program a v t) = Program a v <$> annotateTerm t
 
 -- | Annotate a PLC term, so that all names are annotated with their types/kinds.
 annotateTerm :: (MonadError (Error a) m) => Term TyName Name a -> m (Term TyNameWithKind NameWithType a)
-annotateTerm t = do
-    (t', _) <- liftEither $ convertError $ runStateT (annotateT t) mempty
-    pure t'
+annotateTerm t = fmap fst $ liftEither $ convertError $ runStateT (annotateT t) mempty
 
 -- | Annotate a PLC type, so that all names are annotated with their types/kinds.
 annotateType :: (MonadError (Error a) m) => Type TyName a -> m (Type TyNameWithKind a)
-annotateType t = do
-    (t', _) <- liftEither $ convertError $ runStateT (annotateTy t) mempty
-    pure t'
+annotateType t = fmap fst $ liftEither $ convertError $ runStateT (annotateTy t) mempty
 
 insertType :: Int -> Type TyNameWithKind a -> TypeM a ()
 insertType = modify .* over terms .* IM.insert

--- a/language-plutus-core/src/Language/PlutusCore/TH.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TH.hs
@@ -121,7 +121,7 @@ Finally, we need to drop the lexer position annotations, since they're not terri
 
 compileTerm :: String -> Q Exp
 compileTerm s = do
-    compileTimeT <- eval $ parseTermQ $ strToBs s
+    compileTimeT <- eval $ parseTerm $ strToBs s
     let
         tyMetavars = metavarMapType (ftvTerm compileTimeT)
         termMetavars = metavarMapTerm (fvTerm compileTimeT)
@@ -130,14 +130,14 @@ compileTerm s = do
             quoted :: Quote (Term TyName Name ())
             quoted = do
                 -- See note [Parsing and TH stages]
-                runtimeT <- (fmap void . MM.hoist (Identity . unsafeDropErrors) . parseTermQ . strToBs) s
+                runtimeT <- (fmap void . MM.hoist (Identity . unsafeDropErrors) . parseTerm . strToBs) s
                 metavarSubstTerm runtimeT <$> $(tyMetavars) <*> $(termMetavars)
         in quoted
      |]
 
 compileType :: String -> Q Exp
 compileType s = do
-    compileTimeTy <- eval $ parseTypeQ $ strToBs s
+    compileTimeTy <- eval $ parseType $ strToBs s
     let
         tyMetavars = metavarMapType (ftvTy compileTimeTy)
     [|
@@ -145,14 +145,14 @@ compileType s = do
             quoted :: Quote (Type TyName ())
             quoted = do
                 -- See note [Parsing and TH stages]
-                runtimeTy <- (fmap void . MM.hoist (Identity . unsafeDropErrors) . parseTypeQ . strToBs) s
+                runtimeTy <- (fmap void . MM.hoist (Identity . unsafeDropErrors) . parseType . strToBs) s
                 metavarSubstType runtimeTy <$> $(tyMetavars)
           in quoted
       |]
 
 compileProgram :: String -> Q Exp
 compileProgram s = do
-    (Program _ _ compileTimeT) <- eval $ parseProgramQ $ strToBs s
+    (Program _ _ compileTimeT) <- eval $ parseProgram $ strToBs s
     let
         tyMetavars = metavarMapType (ftvTerm compileTimeT)
         termMetavars= metavarMapTerm (fvTerm compileTimeT)
@@ -161,7 +161,7 @@ compileProgram s = do
             quoted :: Quote (Program TyName Name ())
             quoted = do
                 -- See note [Parsing and TH stages]
-                (Program a v runtimeT) <- (fmap void . MM.hoist (Identity . unsafeDropErrors) . parseProgramQ . strToBs) s
+                (Program a v runtimeT) <- (fmap void . MM.hoist (Identity . unsafeDropErrors) . parseProgram . strToBs) s
                 Program a v . metavarSubstTerm runtimeT <$> $(tyMetavars) <*> $(termMetavars)
         in quoted
      |]

--- a/language-plutus-core/src/Language/PlutusCore/Type.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Type.hs
@@ -244,12 +244,12 @@ instance (PrettyCfg (f a)) => PrettyCfg (Type f a) where
 
 type RenamedTerm a = Term TyNameWithKind NameWithType a
 newtype NameWithType a = NameWithType (Name (a, RenamedType a))
-    deriving (Functor, Generic)
+    deriving (Show, Eq, Functor, Generic)
     deriving newtype NFData
 
 type RenamedType a = Type TyNameWithKind a
 newtype TyNameWithKind a = TyNameWithKind { unTyNameWithKind :: TyName (a, Kind a) }
-    deriving (Eq, Functor, Generic)
+    deriving (Show, Eq, Functor, Generic)
     deriving newtype NFData
 
 instance PrettyCfg (TyNameWithKind a) where

--- a/language-plutus-core/test/Evaluation/TypeCheck.hs
+++ b/language-plutus-core/test/Evaluation/TypeCheck.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Evaluation.TypeCheck
     ( test_typecheck
     ) where
@@ -13,7 +13,7 @@ import           Language.PlutusCore.StdLib.Data.List
 import           Language.PlutusCore.StdLib.Data.Nat
 import           Language.PlutusCore.StdLib.Data.Unit
 
-import Control.Monad.Except
+import           Control.Monad.Except
 
 import           Data.Foldable
 import           Test.Tasty
@@ -30,7 +30,7 @@ assertQuoteWellTyped getTerm = case runExcept $ runQuoteT $ typecheck getTerm of
 assertQuoteIllTyped :: HasCallStack => Quote (Term TyName Name ()) -> Assertion
 assertQuoteIllTyped getTerm = case runExcept $ runQuoteT $ typecheck getTerm of
     Right term -> assertFailure $ "Well-typed: " ++ prettyCfgString term
-    Left _ -> return ()
+    Left _     -> return ()
 
 typecheck :: (MonadError (Error ()) m, MonadQuote m) => Quote (Term TyName Name ()) -> m ()
 typecheck getTerm = do

--- a/language-plutus-core/test/Spec.hs
+++ b/language-plutus-core/test/Spec.hs
@@ -114,6 +114,6 @@ tests :: TestTree
 tests = testCase "example programs" $ fold
     [ format cfg "(program 0.1.0 [(con addInteger) x y])" @?= Right "(program 0.1.0\n  [ [ (con addInteger) x ] y ]\n)"
     , format cfg "(program 0.1.0 doesn't)" @?= Right "(program 0.1.0\n  doesn't\n)"
-    , format cfg "{- program " @?= Left (LexErr "Error in nested comment at line 1, column 12")
+    , format cfg "{- program " @?= Left (ParseError (LexErr "Error in nested comment at line 1, column 12"))
     ]
     where cfg = defaultCfg

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -42145,6 +42145,7 @@ bytestring
 containers
 hedgehog
 mmorph
+mtl
 prettyprinter
 tasty
 tasty-golden


### PR DESCRIPTION
This gets us to the point where *most* of the bits of `language-plutus-core` are using a consistent interface, and there are significantly fewer ways of doing things floating around.

- Annotation and typechecking use `Quote` both externally and internally where appropriate.
    - As a bonus, this means that we can use the stdlib definitions of booleans in the typechecker.
- Most of the modules just export top-level functions for working ontypes/terms/programs as appropriate.

The one bit that remains inconsistent is the parser/renamer, since they
share a bit of state that they pass around. I think the thing to do
would be to have the renamer just calculate its initial state from
the term it is passed in.