### PR TITLE
[CGP-276] Typechecker: handle redexes in all places

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore/Renamer.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Renamer.hs
@@ -80,9 +80,9 @@ annotateT (Constant x c) =
 annotateT (TyInst x t ty) =
     TyInst x <$> annotateT t <*> annotateTy ty
 annotateT (Wrap x (TyName (Name x' b u@(Unique i))) ty t) = do
-    aty <- annotateTy ty
     let k = Type x'
     insertKind i k
+    aty <- annotateTy ty
     let nwty = TyNameWithKind (TyName (Name (x', k) b u))
     Wrap x nwty aty <$> annotateT t
 

--- a/language-plutus-core/src/Language/PlutusCore/Renamer.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Renamer.hs
@@ -91,7 +91,7 @@ annotateTy (TyVar x (TyName (Name x' b (Unique u)))) = do
     st <- gets _types
     case IM.lookup u st of
         Just ty -> pure $ TyVar x (TyNameWithKind (TyName (Name (x', ty) b (Unique u))))
-        Nothing -> throwError $ UnboundVar (Name x' b (Unique u))
+        Nothing -> throwError $ UnboundTyVar (TyName (Name x' b (Unique u)))
 annotateTy (TyLam x (TyName (Name x' s u@(Unique i))) k ty) = do
     insertKind i k
     let nwty = TyNameWithKind (TyName (Name (x', k) s u))

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -227,7 +227,7 @@ typeOf (Unwrap x body) = do
     reducedBodyTy <- tyReduce bodyTy
     case reducedBodyTy of
         TyFix _ n fixArg -> tySubstitute (extractUnique n) reducedBodyTy fixArg
-        _             -> throwError (TypeMismatch x (void body) (TyFix () dummyTyName dummyType) (void bodyTy))
+        _                -> throwError (TypeMismatch x (void body) (TyFix () dummyTyName dummyType) (void bodyTy))
 typeOf t@(Wrap x n ty body) = do
     bodyTy <- typeOf body
     reducedBodyTy <- tyReduce bodyTy

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -204,6 +204,7 @@ typeOf (Apply x fun arg) = do
             reducedInTy <- tyReduce i
             argTy <- typeOf arg
             reducedArgTy <- tyReduce argTy
+            -- for the equality check
             typeCheckStep
             if reducedInTy == reducedArgTy
                 then pure o
@@ -215,6 +216,7 @@ typeOf (TyInst x instBody instArgTy) = do
     case reducedBodyTy of
         TyForall _ n k tyBody -> do
             k' <- kindOf instArgTy
+            -- for the equality check
             typeCheckStep
             if k == k'
                 then tySubstitute (extractUnique n) (void instArgTy) tyBody
@@ -231,6 +233,8 @@ typeOf t@(Wrap x n ty body) = do
     reducedBodyTy <- tyReduce bodyTy
     fixed <- tySubstitute (extractUnique n) (TyFix () (void n) (void ty)) (void ty)
     reducedF <- tyReduce fixed
+    -- for the equality check
+    typeCheckStep
     if reducedBodyTy == reducedF
         then pure (TyFix () (void n) (void ty))
         else throwError (TypeMismatch x (void t) (void bodyTy) fixed)

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -228,7 +228,7 @@ typeOf (Unwrap x body) = do
     case reducedBodyTy of
         TyFix _ n fixArg -> tySubstitute (extractUnique n) reducedBodyTy fixArg
         _                -> throwError (TypeMismatch x (void body) (TyFix () dummyTyName dummyType) (void bodyTy))
-typeOf t@(Wrap x n ty body) = do
+typeOf (Wrap x n ty body) = do
     bodyTy <- typeOf body
     reducedBodyTy <- tyReduce bodyTy
     fixed <- tySubstitute (extractUnique n) (TyFix () (void n) (void ty)) (void ty)
@@ -237,7 +237,7 @@ typeOf t@(Wrap x n ty body) = do
     typeCheckStep
     if reducedBodyTy == reducedF
         then pure (TyFix () (void n) (void ty))
-        else throwError (TypeMismatch x (void t) (void bodyTy) fixed)
+        else throwError (TypeMismatch x (void body) fixed (void bodyTy))
 
 extractUnique :: TyNameWithKind a -> Unique
 extractUnique = nameUnique . unTyName . unTyNameWithKind

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -215,16 +215,14 @@ typeOf (TyInst x t ty) = do
             k' <- kindOf ty
             typeCheckStep
             if k == k'
-                then tySubstitute (extractUnique n) (void ty) ty'' >>= tyReduce
+                then tySubstitute (extractUnique n) (void ty) ty''
                 else throwError (KindMismatch x (void ty) k k')
         _ -> throwError (TypeMismatch x (void t) (TyForall () dummyTyName dummyKind dummyType) (void ty'))
 typeOf (Unwrap x t) = do
     ty <- typeOf t
     reduced <- tyReduce ty
     case reduced of
-        TyFix _ n ty' -> do
-            subst <- tySubstitute (extractUnique n) ty ty'
-            tyReduce subst
+        TyFix _ n ty' -> tySubstitute (extractUnique n) ty ty'
         _             -> throwError (TypeMismatch x (void t) (TyFix () dummyTyName dummyType) (void ty))
 typeOf t@(Wrap x n@(TyNameWithKind (TyName (Name _ _ u))) ty t') = do
     ty' <- typeOf t'

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -215,7 +215,7 @@ typeOf (TyInst x t ty) = do
             if k == k'
                 then pure (tyReduce (tySubstitute (extractUnique n) (void ty) ty''))
                 else throwError (KindMismatch x (void ty) k k')
-        _ -> throwError (TypeMismatch x (void t) (TyForall () dummyTyName dummyKind dummyType) (void ty))
+        _ -> throwError (TypeMismatch x (void t) (TyForall () dummyTyName dummyKind dummyType) (void ty'))
 typeOf (Unwrap x t) = do
     ty <- typeOf t
     case ty of

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -198,7 +198,8 @@ typeOf (Constant _ (BuiltinBS _ n _))            = pure (bsType n)
 typeOf (Constant _ (BuiltinSize _ n))            = pure (sizeType n)
 typeOf (Apply x t t') = do
     ty <- typeOf t
-    case ty of
+    reduced <- tyReduce ty
+    case reduced of
         TyFun _ ty' ty'' -> do
             ty''' <- typeOf t'
             typeCheckStep
@@ -208,7 +209,8 @@ typeOf (Apply x t t') = do
         _ -> throwError (TypeMismatch x (void t) (TyFun () dummyType dummyType) ty)
 typeOf (TyInst x t ty) = do
     ty' <- typeOf t
-    case ty' of
+    reduced <- tyReduce ty'
+    case reduced of
         TyForall _ n k ty'' -> do
             k' <- kindOf ty
             typeCheckStep
@@ -218,7 +220,8 @@ typeOf (TyInst x t ty) = do
         _ -> throwError (TypeMismatch x (void t) (TyForall () dummyTyName dummyKind dummyType) (void ty'))
 typeOf (Unwrap x t) = do
     ty <- typeOf t
-    case ty of
+    reduced <- tyReduce ty
+    case reduced of
         TyFix _ n ty' -> do
             subst <- tySubstitute (extractUnique n) ty ty'
             tyReduce subst

--- a/language-plutus-core/test/types/addInteger.plc.golden
+++ b/language-plutus-core/test/types/addInteger.plc.golden
@@ -1,1 +1,1 @@
-Error at 3:12. Variable t is not in scope.
+Error at 3:12. Type variable t is not in scope.

--- a/language-plutus-core/test/types/applicationRedexes.plc
+++ b/language-plutus-core/test/types/applicationRedexes.plc
@@ -1,0 +1,7 @@
+(program 1.0.0 
+  (lam f [(lam t (type) t) (fun [(con integer) (con 64)] [(con integer) (con 64)])]
+    (lam a [(lam t (type) t) [(con integer) (con 64)]]
+      [ f a ]
+    )
+  )
+)

--- a/language-plutus-core/test/types/applicationRedexes.plc.golden
+++ b/language-plutus-core/test/types/applicationRedexes.plc.golden
@@ -1,0 +1,1 @@
+(fun [(lam t (type) t) (fun [(con integer) (con 64)] [(con integer) (con 64)])] (fun [(lam t (type) t) [(con integer) (con 64)]] [(con integer) (con 64)]))

--- a/language-plutus-core/test/types/instantiationRedexes.plc
+++ b/language-plutus-core/test/types/instantiationRedexes.plc
@@ -1,0 +1,5 @@
+(program 1.0.0 
+  (lam a [(lam t (type) t) (all t (type) t)]
+    { a [(lam t (type) t) [(con integer) (con 64)]] }
+  )
+)

--- a/language-plutus-core/test/types/instantiationRedexes.plc.golden
+++ b/language-plutus-core/test/types/instantiationRedexes.plc.golden
@@ -1,0 +1,1 @@
+(fun [(lam t (type) t) (all t (type) t)] [(lam t (type) t) [(con integer) (con 64)]])

--- a/language-plutus-core/test/types/recursiveUnwrap.plc
+++ b/language-plutus-core/test/types/recursiveUnwrap.plc
@@ -1,0 +1,18 @@
+(program 1.0.0
+  (lam x 
+    (fix list (all r (type) (fun r (fun (fun [(con integer) (con 64)] (fun list r)) r))))
+    [ 
+      [
+        { (unwrap x) [(con integer) (con 64)] } 
+        (con 64 ! 0) 
+      ]
+      (lam head
+        [(con integer) (con 64)] 
+        (lam tail
+          (fix list (all r (type) (fun [(con integer) (con 64)] (fun (fun [(con integer) (con 64)] (fun list [(con integer) (con 64)])) [(con integer) (con 64)]))))
+          head
+        )
+      ) 
+    ]
+  )
+)

--- a/language-plutus-core/test/types/recursiveUnwrap.plc.golden
+++ b/language-plutus-core/test/types/recursiveUnwrap.plc.golden
@@ -1,0 +1,1 @@
+(fun (fix list (all r (type) (fun r (fun (fun [(con integer) (con 64)] (fun list r)) r)))) [(con integer) (con 64)])

--- a/language-plutus-core/test/types/recursiveWrap.plc
+++ b/language-plutus-core/test/types/recursiveWrap.plc
@@ -1,0 +1,17 @@
+(program 1.0.0
+  (abs a (type) 
+    (wrap 
+      list 
+      (all r (type) (fun r (fun (fun a (fun list r)) r))) 
+      (abs r (type) 
+        (lam z r 
+          (lam 
+            f 
+            (fun a (fun (fix list (all r (type) (fun r (fun (fun a (fun list r)) r)))) r)) 
+            z
+          )
+        )
+      )
+    )
+  )
+)

--- a/language-plutus-core/test/types/recursiveWrap.plc.golden
+++ b/language-plutus-core/test/types/recursiveWrap.plc.golden
@@ -1,0 +1,18 @@
+Type mismatch at 3:6 in term
+  '(abs
+    r
+    (type)
+    (lam
+      z
+      r
+      (lam
+        f
+        (fun a (fun (fix list (all r (type) (fun r (fun (fun a (fun list r)) r)))) r))
+        z
+      )
+    )
+  )'.
+Expected type
+  '(all r (type) (fun r (fun (fun a (fun (fix list (all r (type) (fun r (fun (fun a (fun list r)) r)))) r)) r)))',
+found type
+  '(all r (type) (fun r (fun (fun a (fun (fix list (all r (type) (fun r (fun (fun a (fun list r)) r)))) r)) r)))'

--- a/language-plutus-core/test/types/redexes.plc
+++ b/language-plutus-core/test/types/redexes.plc
@@ -1,0 +1,21 @@
+(program 1.0.0
+  (lam
+    ds_3
+    [[(lam a_0 (type) (lam b_1 (type) (all p_matchOut_2 (type) (fun (fun a_0 (fun b_1 p_matchOut_2)) p_matchOut_2)))) [(con integer) (con 64)]] [(con integer) (con 64)]]
+    [
+      [
+        { ds_3 (fun (all a_4 (type) (fun a_4 a_4)) [(con integer) (con 64)]) }
+        (lam
+          a_5
+          [(con integer) (con 64)]
+          (lam
+            b_6
+            [(con integer) (con 64)]
+            (lam thunk_7 (all a_8 (type) (fun a_8 a_8)) a_5)
+          )
+        )
+      ]
+      (abs a_9 (type) (lam x_10 a_9 x_10))
+    ]
+  )
+)

--- a/language-plutus-core/test/types/redexes.plc.golden
+++ b/language-plutus-core/test/types/redexes.plc.golden
@@ -1,6 +1,1 @@
-Type mismatch at 7:9 in term
-  'ds_3'.
-Expected type
-  '(all * (type) *)',
-found type
-  '[[(lam a_0 (type) (lam b_1 (type) (all p_matchOut_2 (type) (fun (fun a_0 (fun b_1 p_matchOut_2)) p_matchOut_2)))) [(con integer) (con 64)]] [(con integer) (con 64)]]'
+(fun [[(lam a_0 (type) (lam b_1 (type) (all p_matchOut_2 (type) (fun (fun a_0 (fun b_1 p_matchOut_2)) p_matchOut_2)))) [(con integer) (con 64)]] [(con integer) (con 64)]] [(con integer) (con 64)])

--- a/language-plutus-core/test/types/redexes.plc.golden
+++ b/language-plutus-core/test/types/redexes.plc.golden
@@ -1,0 +1,6 @@
+Type mismatch at 7:9 in term
+  'ds_3'.
+Expected type
+  '(all * (type) *)',
+found type
+  '[[(lam a_0 (type) (lam b_1 (type) (all p_matchOut_2 (type) (fun (fun a_0 (fun b_1 p_matchOut_2)) p_matchOut_2)))) [(con integer) (con 64)]] [(con integer) (con 64)]]'


### PR DESCRIPTION
- We were reporting the wrong type in an error (test on this commit gives wrong message before that, cf CGP-268)
- Type substitution should cost us.
- Reduce types at all times before checking rule applicability.
- Reduce iterated applications correctly.
    - Currently we will reduce one application, but then we will think that we're done, when in fact we have to do it repeatedly until the rule no longer applies.

I *think* this is correct, and it handles the cases I'm interested in at least. This does *not* ensure that the type inferred for a term is reduced, I'm unsure whether that's desirable.