### PR TITLE
Fixed duplicate names where possible

### DIFF
--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/List.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/List.hs
@@ -58,6 +58,9 @@ getBuiltinNil = do
 --
 -- > /\(a :: *) -> \(x : a) (xs : list a) ->
 -- >     wrap /\(r :: *) -> \(z : r) (f : a -> list a -> r) -> f x xs
+--
+-- @listA@ appears twice in types in the term,
+-- so this is not really a definition with unique names.
 getBuiltinCons :: Quote (Term TyName Name ())
 getBuiltinCons = do
     list <- getBuiltinList
@@ -87,6 +90,9 @@ getBuiltinCons = do
 -- > /\(a :: *) (r :: *) -> \(f : r -> a -> r) (z : r) ->
 -- >     fix {list a} {r} \(rec : list a -> r) (xs : list a) ->
 -- >         unwrap xs {r} z \(x : a) (xs' : list a) -> f (rec xs') x
+--
+-- @listA@ appears several times in types in the term,
+-- so this is not really a definition with unique names.
 getBuiltinFoldrList :: Quote (Term TyName Name ())
 getBuiltinFoldrList = do
     list <- getBuiltinList
@@ -122,6 +128,9 @@ getBuiltinFoldrList = do
 -- > /\(a :: *) (r :: *) -> \(f : r -> a -> r) ->
 -- >     fix {r} {list a -> r} \(rec : r -> list a -> r) (z : r) (xs : list a) ->
 -- >         unwrap xs {r} z \(x : a) -> rec (f z x)
+--
+-- @listA@ appears several times in types in the term,
+-- so this is not really a definition with unique names.
 getBuiltinFoldList :: Quote (Term TyName Name ())
 getBuiltinFoldList = do
     list <- getBuiltinList

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Nat.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Nat.hs
@@ -50,6 +50,9 @@ getBuiltinZero = do
 -- |  'succ' as a PLC term.
 --
 -- > \(n : nat) -> wrap /\(r :: *) -> \(z : r) (f : nat -> r) -> f n
+--
+-- @nat@ appears several times in types in the term,
+-- so this is not really a definition with unique names.
 getBuiltinSucc :: Quote (Term TyName Name ())
 getBuiltinSucc = do
     RecursiveType wrapNat nat <- holedToRecursive <$> getBuiltinNat
@@ -71,6 +74,9 @@ getBuiltinSucc = do
 -- > /\(r :: *) -> \(f : r -> r) (z : r) ->
 -- >     fix {nat} {r} \(rec : nat -> r) (n : nat) ->
 -- >         unwrap n {r} z \(n' : nat) -> f (rec n')
+--
+-- @nat@ appears several times in types in the term,
+-- so this is not really a definition with unique names.
 getBuiltinFoldrNat :: Quote (Term TyName Name ())
 getBuiltinFoldrNat = do
     RecursiveType _ nat <- holedToRecursive <$> getBuiltinNat
@@ -99,6 +105,9 @@ getBuiltinFoldrNat = do
 -- > /\(r :: *) -> \(f : r -> r) ->
 -- >     fix {r} {nat -> r} \(rec : r -> nat -> r) (z : r) (n : nat) ->
 -- >         unwrap n {r} z (rec (f z))
+--
+-- @nat@ appears several times in types in the term,
+-- so this is not really a definition with unique names.
 getBuiltinFoldNat :: Quote (Term TyName Name ())
 getBuiltinFoldNat = do
     RecursiveType _ nat <- holedToRecursive <$> getBuiltinNat


### PR DESCRIPTION
This fixes duplicate names inside the stdlib where possible.
Now the problem: you cannot apply the same `list` to `A` and to `B` in a type as that would result in name sharing, because `list` binds an `r` deeply inside.
I will write more on the topic on our mailing list, but let's fix at least booleans for now.