### PR TITLE
TypeSynthesis: get rid of the non-exhaustive pattern match in a slightly better way

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore/Error.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Error.hs
@@ -37,14 +37,14 @@ instance (PrettyCfg a) => PrettyCfg (RenameError a) where
     prettyCfg cfg (UnboundVar n@(Name loc _ _)) = "Error at" <+> prettyCfg cfg loc <> ". Variable" <+> prettyCfg cfg n <+> "is not in scope."
     prettyCfg cfg (UnboundTyVar n@(TyName (Name loc _ _))) = "Error at" <+> prettyCfg cfg loc <> ". Type variable" <+> prettyCfg cfg n <+> "is not in scope."
 
-data TypeError a = InternalError -- ^ This is thrown if builtin lookup fails
+data TypeError a = InternalError T.Text -- ^ This is thrown if builtin lookup fails or there is some other kind of programmer error
                  | KindMismatch a (Type TyNameWithKind ()) (Kind ()) (Kind ())
                  | TypeMismatch a (Term TyNameWithKind NameWithType ()) (Type TyNameWithKind ()) (Type TyNameWithKind ())
                  | OutOfGas
                  deriving (Show, Eq, Generic, NFData)
 
 instance (PrettyCfg a) => PrettyCfg (TypeError a) where
-    prettyCfg _ InternalError               = "Internal error."
+    prettyCfg _ (InternalError t)           = pretty t
     prettyCfg cfg (KindMismatch x ty k k')  = "Kind mismatch at" <+> prettyCfg cfg x <+> "in type" <+> squotes (prettyCfg cfg ty) <> ". Expected kind" <+> squotes (pretty k) <+> ", found kind" <+> squotes (pretty k')
     prettyCfg cfg (TypeMismatch x t ty ty') = "Type mismatch at" <+> prettyCfg cfg x <+> "in term" <> hardline <> indent 2 (squotes (prettyCfg cfg t)) <> "." <> hardline <> "Expected type" <> hardline <> indent 2 (squotes (prettyCfg cfg ty)) <> "," <> hardline <> "found type" <> hardline <> indent 2 (squotes (prettyCfg cfg ty'))
     prettyCfg _ OutOfGas                    = "Type checker ran out of gas."

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -13,14 +13,16 @@ module Language.PlutusCore.TypeSynthesis ( typecheckProgram
 import           Control.Monad.Except
 import           Control.Monad.Reader
 import           Control.Monad.State.Class
-import           Control.Monad.Trans.State.Strict hiding (get, modify)
+import           Control.Monad.Trans.State.Strict     hiding (get, modify)
 import           Data.Functor.Foldable
-import qualified Data.Map                         as M
+import qualified Data.Map                             as M
 import           Language.PlutusCore.Error
 import           Language.PlutusCore.Lexer.Type
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Normalize
 import           Language.PlutusCore.Quote
+import           Language.PlutusCore.Renamer
+import qualified Language.PlutusCore.StdLib.Data.Bool as Std
 import           Language.PlutusCore.Type
 import           PlutusPrelude
 
@@ -37,51 +39,34 @@ isType Type{} = True
 isType _      = False
 
 -- | Create a new 'Type' for an integer operation.
-intop :: (MonadQuote m) => m (Type TyNameWithKind ())
+intop :: MonadQuote m => m (Type TyNameWithKind ())
 intop = do
-    nam <- newTyName (Size ())
+    nam <- liftQuote $ freshTyName () ""
     let ity = TyApp () (TyBuiltin () TyInteger) (TyVar () nam)
         fty = TyFun () ity (TyFun () ity ity)
-    pure $ TyForall () nam (Size ()) fty
+    Right t <- runExceptT $ annotateType $ TyForall () nam (Size ()) fty
+    pure t
 
 -- | Create a new 'Type' for an integer relation
-intRel :: (MonadQuote m)  => m (Type TyNameWithKind ())
+intRel :: MonadQuote m  => m (Type TyNameWithKind ())
 intRel = builtinRel TyInteger
 
-bsRel :: (MonadQuote m) => m (Type TyNameWithKind ())
+bsRel :: MonadQuote m => m (Type TyNameWithKind ())
 bsRel = builtinRel TyByteString
 
--- | Create a dummy 'TyName'
-newTyName :: (MonadQuote m) => Kind () -> m (TyNameWithKind ())
-newTyName k = do
-    u <- nameUnique . unTyName <$> liftQuote (freshTyName () "a")
-    pure $ TyNameWithKind (TyName (Name ((), k) "a" u))
-
-unit :: MonadQuote m => m (Type TyNameWithKind ())
-unit =
-    [ TyForall () nam (Type ()) (TyFun () (TyVar () nam) (TyVar () nam)) | nam <- newTyName (Type ()) ]
-
-boolean :: MonadQuote m => m (Type TyNameWithKind ())
-boolean = do
-    nam <- newTyName (Type ())
-    (u, u') <- (,) <$> unit <*> unit
-    let var = TyVar () nam
-        unitVar = TyFun () u var
-        unitVar' = TyFun () u' var
-    pure $ TyForall () nam (Type ()) (TyFun () unitVar (TyFun () unitVar' var))
-
-builtinRel :: (MonadQuote m) => TypeBuiltin -> m (Type TyNameWithKind ())
+builtinRel :: MonadQuote m => TypeBuiltin -> m (Type TyNameWithKind ())
 builtinRel bi = do
-    nam <- newTyName (Size ())
-    b <- boolean
+    nam <- liftQuote $ freshTyName () ""
+    b <- liftQuote Std.getBuiltinBool
     let ity = TyApp () (TyBuiltin () bi) (TyVar () nam)
         fty = TyFun () ity (TyFun () ity b)
-    pure $ TyForall () nam (Size ()) fty
+    Right t <- runExceptT $ annotateType $ TyForall () nam (Size ()) fty
+    pure t
 
 txHash :: Type TyNameWithKind ()
 txHash = TyApp () (TyBuiltin () TyByteString) (TyInt () 256)
 
-defaultTable :: (MonadQuote m) => m BuiltinTable
+defaultTable :: MonadQuote m => m BuiltinTable
 defaultTable = do
 
     let tyTable = M.fromList [ (TyByteString, KindArrow () (Size ()) (Type ()))


### PR DESCRIPTION
The action is in the second commit. We already have `InternalError` to signal "programmer error", so use that.