### PR TITLE
Leading characters in identifiers can be upper or lower case

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore/Lexer.x
+++ b/language-plutus-core/src/Language/PlutusCore/Lexer.x
@@ -44,7 +44,7 @@ $upper = [A-Z]
 @float = @sign $digit+ (\. $digit+ (@exp | "") | @exp)
 @size = $digit+
 
-@identifier = $lower [$lower $upper $digit \_ \']*
+@identifier = [$lower $upper][$lower $upper $digit \_ \']*
 
 @special = \\\\ | \\\"
 


### PR DESCRIPTION
This change looks like it sneaked into the spec without anyone noticing.