### PR TITLE
Add plutus-core-interpreter to the CI

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -16,6 +16,7 @@ let
   platforms = {
     plutus-prototype = supportedSystems;
     language-plutus-core = supportedSystems;
+    plutus-core-interpreter = supportedSystems;
     plutus-core-spec = supportedSystems;
   };
   mapped = mapTestOn platforms;


### PR DESCRIPTION
I've recently realised that we need to do this when we add a package if we want it to be built by the CI.