### PR TITLE
plutus-exe: split out from language-plutus-core, use CEK machine

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -55,6 +55,7 @@ let
       # we want to enable benchmarking, which also means we have criterion in the corresponding env
       language-plutus-core = appendConfigureFlag (doBenchmark (doHaddockHydra (addRealTimeTestLogs (filterSource super.language-plutus-core)))) "--enable-benchmarks";
       plutus-core-interpreter = doHaddockHydra (addRealTimeTestLogs (filterSource super.plutus-core-interpreter));
+      plutus-exe = addRealTimeTestLogs (filterSource super.plutus-exe);
     };
   };
   other = rec {

--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -118,26 +118,6 @@ library
     if impl(ghc >=8.4)
         ghc-options: -Wmissing-export-lists
 
-executable plc
-    main-is: Main.hs
-    hs-source-dirs: plutus-exe
-    default-language: Haskell2010
-    ghc-options: -Wall -Wincomplete-uni-patterns
-                 -Wincomplete-record-updates -Wredundant-constraints -Widentities
-    build-depends:
-        base -any,
-        language-plutus-core -any,
-        bytestring -any,
-        text -any,
-        mtl -any,
-        optparse-applicative -any
-
-    if (flag(development) && impl(ghc <8.4))
-        ghc-options: -Werror
-
-    if impl(ghc >=8.4)
-        ghc-options: -Wmissing-export-lists
-
 executable language-plutus-core-generate-evaluation-test
     main-is: Main.hs
     hs-source-dirs: generate-evaluation-test

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -99,6 +99,8 @@ module Language.PlutusCore
     , plcProgram
     -- * Evaluation
     , parseRunCk
+    , runCk
+    , evaluateCk
     , EvaluationResult (..)
     ) where
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -42082,7 +42082,6 @@ license = stdenv.lib.licenses.bsd3;
 , microlens
 , mmorph
 , mtl
-, optparse-applicative
 , prettyprinter
 , recursion-schemes
 , safe-exceptions
@@ -42134,8 +42133,6 @@ base
 bytestring
 hedgehog
 mmorph
-mtl
-optparse-applicative
 prettyprinter
 text
 ];
@@ -55495,6 +55492,39 @@ text
 ];
 doHaddock = false;
 description = "Virtual machine for Plutus Core";
+license = stdenv.lib.licenses.bsd3;
+
+}) {};
+"plutus-exe" = callPackage
+({
+  mkDerivation
+, base
+, bytestring
+, language-plutus-core
+, mtl
+, optparse-applicative
+, plutus-core-interpreter
+, stdenv
+, text
+}:
+mkDerivation {
+
+pname = "plutus-exe";
+version = "0.1.0.0";
+src = ./../plutus-exe;
+isLibrary = false;
+isExecutable = true;
+executableHaskellDepends = [
+base
+bytestring
+language-plutus-core
+mtl
+optparse-applicative
+plutus-core-interpreter
+text
+];
+doHaddock = false;
+description = "Executable for Plutus Core tools";
 license = stdenv.lib.licenses.bsd3;
 
 }) {};

--- a/plutus-exe/LICENSE
+++ b/plutus-exe/LICENSE
@@ -1,0 +1,11 @@
+Copyright Input Output (c) 2018
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/plutus-exe/plutus-exe.cabal
+++ b/plutus-exe/plutus-exe.cabal
@@ -1,0 +1,38 @@
+cabal-version: 2.0
+name: plutus-exe
+version: 0.1.0.0
+license: BSD3
+license-file: LICENSE
+copyright: Copyright: (c) 2018 Input Output
+maintainer: michael.peyton-jones@iohk.io
+author: Michael Peyton jones
+tested-with: ghc ==8.2.2 ghc ==8.4.3 ghc ==8.6.1
+synopsis: Executable for Plutus Core tools.
+description:
+    Exectuable for Plutus Core tools.
+category: Language, Plutus
+build-type: Simple
+extra-source-files:
+extra-doc-files: README.md
+
+source-repository head
+    type: git
+    location: https://github.com/input-output-hk/plutus-prototype
+
+executable plc
+    main-is: Main.hs
+    hs-source-dirs: src
+    default-language: Haskell2010
+    ghc-options: -Wall -Wincomplete-uni-patterns
+                 -Wincomplete-record-updates -Wredundant-constraints -Widentities
+    build-depends:
+        base -any,
+        language-plutus-core -any,
+        plutus-core-interpreter -any,
+        bytestring -any,
+        text -any,
+        mtl -any,
+        optparse-applicative -any
+
+    if impl(ghc >=8.4)
+        ghc-options: -Wmissing-export-lists

--- a/plutus-exe/shell.nix
+++ b/plutus-exe/shell.nix
@@ -1,0 +1,1 @@
+(import ../. {}).plutus-exe.env

--- a/release.nix
+++ b/release.nix
@@ -17,6 +17,7 @@ let
     plutus-prototype = supportedSystems;
     language-plutus-core = supportedSystems;
     plutus-core-interpreter = supportedSystems;
+    plutus-exe = supportedSystems;
     # don't need to build the spec on anything other than one platform
     plutus-core-spec = [ "x86_64-linux" ];
   };

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,7 @@ packages:
 - plutus-prototype
 - language-plutus-core
 - plutus-core-interpreter
+- plutus-exe
 
 - location:
     git: https://github.com/input-output-hk/cardano-crypto


### PR DESCRIPTION
As suggested in previous discussion. There is a `--mode` flag that lets you use the CK machine if you like, but the default is the CEK machine.