### PR TITLE
Distinguish normalized types with a newtype wrapper

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -148,7 +148,7 @@ parseScoped :: (MonadError (Error AlexPosn) m) => BSL.ByteString -> m (Program T
 parseScoped str = liftEither $ convertError $ fmap (\(p, s) -> rename s p) $ runExcept $ runStateT (parseST str) emptyIdentifierState
 
 -- | Parse a program and typecheck it.
-parseTypecheck :: (MonadError (Error AlexPosn) m, MonadQuote m) => Natural -> BSL.ByteString -> m (Type TyNameWithKind ())
+parseTypecheck :: (MonadError (Error AlexPosn) m, MonadQuote m) => Natural -> BSL.ByteString -> m (NormalizedType TyNameWithKind ())
 parseTypecheck gas bs = do
     parsed <- parseProgram bs
     checkProgram parsed

--- a/language-plutus-core/src/Language/PlutusCore/Error.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Error.hs
@@ -39,7 +39,7 @@ instance (PrettyCfg a) => PrettyCfg (RenameError a) where
 
 data TypeError a = InternalError -- ^ This is thrown if builtin lookup fails
                  | KindMismatch a (Type TyNameWithKind ()) (Kind ()) (Kind ())
-                 | TypeMismatch a (Term TyNameWithKind NameWithType ()) (Type TyNameWithKind ()) (Type TyNameWithKind ())
+                 | TypeMismatch a (Term TyNameWithKind NameWithType ()) (Type TyNameWithKind ()) (NormalizedType TyNameWithKind ())
                  | OutOfGas
                  deriving (Show, Eq, Generic, NFData)
 

--- a/language-plutus-core/src/Language/PlutusCore/Type.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Type.hs
@@ -25,6 +25,8 @@ module Language.PlutusCore.Type ( Term (..)
                                 , RenamedType
                                 , RenamedTerm
                                 , TyNameWithKind (..)
+                                -- * Normalized types
+                                , NormalizedType (..)
                                 ) where
 
 import qualified Data.ByteString.Lazy           as BSL
@@ -259,3 +261,10 @@ instance PrettyCfg (TyNameWithKind a) where
 instance PrettyCfg (NameWithType a) where
     prettyCfg cfg@(Configuration _ True) (NameWithType n@(Name (_, ty) _ _)) = parens (prettyCfg cfg n <+> ":" <+> prettyCfg cfg ty)
     prettyCfg cfg@(Configuration _ False) (NameWithType n) = prettyCfg cfg n
+
+newtype NormalizedType tyname a = NormalizedType { getNormalizedType :: Type tyname a }
+    deriving (Show, Eq, Functor, Generic)
+    deriving newtype NFData
+
+instance PrettyCfg (tyname a) => PrettyCfg (NormalizedType tyname a) where
+    prettyCfg cfg (NormalizedType ty) = prettyCfg cfg ty

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -228,7 +228,7 @@ typeOf (TyInst x body ty) = do
             k' <- kindOf ty
             typeCheckStep
             if k == k'
-                then pure (tyReduce (tySubstitute (extractUnique n) nBodyTy (NormalizedType absTy)))
+                then pure (tyReduce (tySubstitute (extractUnique n) (void $ NormalizedType ty) (NormalizedType absTy)))
                 else throwError (KindMismatch x (void ty) k k')
         _ -> throwError (TypeMismatch x (void body) (TyForall () dummyTyName dummyKind dummyType) nBodyTy)
 typeOf (Unwrap x body) = do


### PR DESCRIPTION
This adds a `NormalizedType` newtype wrapper for normalized types. It's not quite making illegal states unrepresentable, because there's nothing preventing you from lying, but I think the clarity improvement is just about worth the book-keeping.

The current approach highlights the places where we assert that types are normalized: when picking them up from terms, and (suspiciously) after we substitute during reduction. (I think this might be a bug).

In addition, I made `tySubstitute` take `NormalizedType`s. This is desirable - if we allow either of the arguments to be non-normalized we can create redundant work by substituting in/substituting into things that we're going to reduce away.

I also tried a more heavy-weight approach here: https://github.com/michaelpj/plutus-prototype/commit/2cb2fba33db77bdf96a48c05879079b8fd17cd3e. There I added a type parameter to everything representing the `Type` constructor. This reduced some book-keeping in the typechecker, because terms already contained normalized types, and we could then say that `checkProgram` turned a `Program Type TyName Name a` into a `Program NormalizedType TyName Name a`. However, while *possibly* this is worth the effort when the typechecker needs to only consume programs with normalized types, given that we're moving in the direction of allowing all types everywhere, everything would be using `Program Type TyName Name a` anyway, so there would be very little benefit.

Thoughts and alternative approaches welcome!