### PR TITLE
Added 'typeOfBuiltinName'

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,7 +1,7 @@
 ---
 - functions:
   - {name: unsafePerformIO, within: [PlutusPrelude, Language.PlutusCore.Generators.Internal.Entity]}
-  - {name: error, within: [Main, Language.PlutusCore.Generators.Interesting, Evaluation.Constant.Success, Language.PlutusCore.Constant.Apply, Language.PlutusCore.Evaluation.CkMachine, Language.PlutusCore.Generators.Internal.Entity, Language.PlutusCore.Constant.Make, Language.PlutusCore.Generators.Internal.TypedBuiltinGen, Language.PlutusCore.TH]}
+  - {name: error, within: [Main, Language.PlutusCore.Generators.Interesting, Evaluation.Constant.Success, Language.PlutusCore.Constant.Apply, Language.PlutusCore.Constant.Typed, Language.PlutusCore.Evaluation.CkMachine, Language.PlutusCore.Generators.Internal.Entity, Language.PlutusCore.Constant.Make, Language.PlutusCore.Generators.Internal.TypedBuiltinGen, Language.PlutusCore.TH]}
   - {name: undefined, within: [Language.PlutusCore.Constant.Apply]}
   - {name: fromJust, within: []}
   - {name: foldl, within: []}

--- a/language-plutus-core/src/Language/PlutusCore/Name.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Name.hs
@@ -12,6 +12,8 @@ module Language.PlutusCore.Name ( -- * Types
                                 , newIdentifier
                                 , emptyIdentifierState
                                 , identifierStateFrom
+                                , mapNameString
+                                , mapTyNameString
                                 ) where
 
 import           Control.Monad.State
@@ -36,6 +38,14 @@ data Name a = Name { nameAttribute :: a
 newtype TyName a = TyName { unTyName :: Name a }
     deriving (Show, Lift)
     deriving newtype (Eq, Ord, Functor, NFData, PrettyCfg)
+
+-- | Apply a function to the string representation of a 'Name'.
+mapNameString :: (BSL.ByteString -> BSL.ByteString) -> Name a -> Name a
+mapNameString f name = name { nameString = f $ nameString name }
+
+-- | Apply a function to the string representation of a 'TyName'.
+mapTyNameString :: (BSL.ByteString -> BSL.ByteString) -> TyName a -> TyName a
+mapTyNameString f (TyName name) = TyName $ mapNameString f name
 
 instance Eq (Name a) where
     (==) = (==) `on` nameUnique


### PR DESCRIPTION
For example

```
 prettyCfgString . runQuote $ typeOfBuiltinName ResizeInteger
"(all s0 (size) (all s1 (size) (fun [(con size) s1] (fun [(con integer) s0] [(con integer) s1]))))"
 prettyCfgString . runQuote $ typeOfBuiltinName IntToByteString
"(all s0 (size) (all s1 (size) (fun [(con size) s1] (fun [(con integer) s0] [(con bytestring) s1]))))"
 prettyCfgString . runQuote $ typeOfBuiltinName Concatenate
"(all s0 (size) (fun [(con bytestring) s0] (fun [(con bytestring) s0] [(con bytestring) s0])))"
 prettyCfgString . runQuote $ typeOfBuiltinName MultiplyInteger
"(all s0 (size) (fun [(con integer) s0] (fun [(con integer) s0] [(con integer) s0])))"
```