### PR TITLE
Plugin: fail on casts

### DIFF
--- a/core-to-plc/src/Language/Plutus/CoreToPLC.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC.hs
@@ -273,8 +273,8 @@ getDataCons tc
         GHC.AbstractTyCon                -> unsupported $ "Abstract type:" GHC.<+> GHC.ppr tc
         GHC.DataTyCon{GHC.data_cons=dcs} -> pure dcs
         GHC.TupleTyCon{GHC.data_con=dc}  -> pure [dc]
-        GHC.SumTyCon{}                   -> unsupported $ "Sum type:" GHC.<+> GHC.ppr tc
-        GHC.NewTyCon{}                   -> unsupported $ "Newtype:" GHC.<+> GHC.ppr tc
+        GHC.SumTyCon{GHC.data_cons=dcs}  -> pure dcs
+        GHC.NewTyCon{GHC.data_con=dc}    -> pure [dc]
     | otherwise = unsupported $ "Type constructor:" GHC.<+> GHC.ppr tc
 
 -- This is the creation of the Scott-encoded datatype type. See Note [Scott encoding of datatypes]

--- a/core-to-plc/src/Language/Plutus/CoreToPLC.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC.hs
@@ -723,6 +723,6 @@ convExpr e = do
         -- ignore annotation
         GHC.Tick _ body -> convExpr body
         -- just go straight to the body, we don't care about the nominal types
-        GHC.Cast body _ -> convExpr body
+        GHC.Cast _ coerce -> unsupported $ "Unsupported: coercion" GHC.$+$ GHC.ppr coerce
         GHC.Type _ -> conversionFail "Cannot convert types directly, only as arguments to applications"
         GHC.Coercion _ -> conversionFail "Coercions should not be converted"

--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -109,6 +109,7 @@ datat :: TestTree
 datat = testGroup "Data" [
     monoData
   , polyData
+  , newtypes
   ]
 
 monoData :: TestTree
@@ -156,6 +157,22 @@ polyDataType = plc (\(x:: MyPolyData Int Int) -> x)
 
 polyConstructed :: PlcCode
 polyConstructed = plc (Poly1 (1::Int) (2::Int))
+
+newtypes :: TestTree
+newtypes = testGroup "Newtypes" [
+    golden "basicNewtype" basicNewtype
+   --, golden "newtypeMatch" newtypeMatch
+   ]
+
+newtype MyNewtype = MyNewtype Int
+
+basicNewtype :: PlcCode
+basicNewtype = plc (\(x::MyNewtype) -> x)
+
+{- CGP-286, this creates a coercion
+newtypeMatch :: PlcCode
+newtypeMatch = plc (\(MyNewtype x) -> x)
+-}
 
 recursion :: TestTree
 recursion = testGroup "Recursive functions" [

--- a/core-to-plc/test/basicNewtype.plc.golden
+++ b/core-to-plc/test/basicNewtype.plc.golden
@@ -1,0 +1,7 @@
+(program 1.0.0
+  (lam
+    ds_1
+    (all MyNewtype_matchOut_0 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_0) MyNewtype_matchOut_0))
+    ds_1
+  )
+)


### PR DESCRIPTION
Ignoring these is definitely wrong. I think I know how to handle the newtype coercions, but for now make sure we don't blindly generate the wrong code!