### PR TITLE
[CGP-286] Convert newtype coercions into explicit wraps and unwraps

### DIFF
--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -161,18 +161,26 @@ polyConstructed = plc (Poly1 (1::Int) (2::Int))
 newtypes :: TestTree
 newtypes = testGroup "Newtypes" [
     golden "basicNewtype" basicNewtype
-   --, golden "newtypeMatch" newtypeMatch
+   , golden "newtypeMatch" newtypeMatch
+   , golden "newtypeCreate" newtypeCreate
+   , golden "nestedNewtypeMatch" nestedNewtypeMatch
    ]
 
 newtype MyNewtype = MyNewtype Int
 
+newtype MyNewtype2 = MyNewtype2 MyNewtype
+
 basicNewtype :: PlcCode
 basicNewtype = plc (\(x::MyNewtype) -> x)
 
-{- CGP-286, this creates a coercion
 newtypeMatch :: PlcCode
 newtypeMatch = plc (\(MyNewtype x) -> x)
--}
+
+newtypeCreate :: PlcCode
+newtypeCreate = plc (\(x::Int) -> MyNewtype x)
+
+nestedNewtypeMatch :: PlcCode
+nestedNewtypeMatch = plc (\(MyNewtype2 (MyNewtype x)) -> x)
 
 recursion :: TestTree
 recursion = testGroup "Recursive functions" [

--- a/core-to-plc/test/nestedNewtypeMatch.plc.golden
+++ b/core-to-plc/test/nestedNewtypeMatch.plc.golden
@@ -1,0 +1,23 @@
+(program 1.0.0
+  (lam
+    ds_2
+    (all MyNewtype2_matchOut_0 (type) (fun (fun (all MyNewtype_matchOut_1 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_1) MyNewtype_matchOut_1)) MyNewtype2_matchOut_0) MyNewtype2_matchOut_0))
+    [
+      {
+        [
+          {
+            ds_2
+            (all MyNewtype_matchOut_3 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_3) MyNewtype_matchOut_3))
+          }
+          (lam
+            inner_4
+            (all MyNewtype_matchOut_3 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_3) MyNewtype_matchOut_3))
+            inner_4
+          )
+        ]
+        [(con integer) (con 64)]
+      }
+      (lam inner_5 [(con integer) (con 64)] inner_5)
+    ]
+  )
+)

--- a/core-to-plc/test/newtypeCreate.plc.golden
+++ b/core-to-plc/test/newtypeCreate.plc.golden
@@ -1,0 +1,11 @@
+(program 1.0.0
+  (lam
+    ds_0
+    [(con integer) (con 64)]
+    (abs
+      match_out_1
+      (type)
+      (lam c_2 (fun [(con integer) (con 64)] match_out_1) [ c_2 ds_0 ])
+    )
+  )
+)

--- a/core-to-plc/test/newtypeMatch.plc.golden
+++ b/core-to-plc/test/newtypeMatch.plc.golden
@@ -1,0 +1,10 @@
+(program 1.0.0
+  (lam
+    ds_1
+    (all MyNewtype_matchOut_0 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_0) MyNewtype_matchOut_0))
+    [
+      { ds_1 [(con integer) (con 64)] }
+      (lam inner_2 [(con integer) (con 64)] inner_2)
+    ]
+  )
+)


### PR DESCRIPTION
This adds support for newtypes by treating them as data constructors with a single constructor. We handle coercions by looking for coercions between a newtype and its definition. If we find such a wrap or unwrap, we handle it by either creating a trivial match or wrapping up the value.

It would be nice to also offer GHC's guarantee that newtypes are represented exactly as the underlying type, but I think we can view that as future optimization (I'll open a ticket).