### PR TITLE
[CGP-287] Give a better error for use of `Integer`

### DIFF
--- a/core-to-plc/src/Language/Plutus/CoreToPLC.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC.hs
@@ -205,6 +205,8 @@ convTyConApp tc ts
     | tc == GHC.intTyCon = pure $ appSize haskellIntSize (PLC.TyBuiltin () PLC.TyInteger)
     -- this is Int#, can we do this nicer?
     | (GHC.getOccString $ GHC.tyConName tc) == "Int#" = pure $ appSize haskellIntSize (PLC.TyBuiltin () PLC.TyInteger)
+    -- we don't support Integer
+    | GHC.tyConName tc == GHC.integerTyConName = unsupported "Integer: use Int instead"
     | otherwise = do
         tc' <- convTyCon tc
         args' <- mapM convType ts

--- a/core-to-plc/src/Language/Plutus/CoreToPLC.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC.hs
@@ -90,6 +90,11 @@ conversionFail = (throwError . ConversionError) <=< sdToTxt
 unsupported :: (MonadError (Error ()) m, MonadReader ConvertingState m) => GHC.SDoc -> m a
 unsupported = (throwError . UnsupportedError) <=< sdToTxt
 
+context :: (MonadError (Error ()) m, MonadReader ConvertingState m) => GHC.SDoc -> (Error ()) -> m a
+context sd err = do
+    txt <- sdToTxt sd
+    throwError $ Context txt err
+
 freeVariable :: (MonadError (Error ()) m, MonadReader ConvertingState m) => GHC.SDoc -> m a
 freeVariable = (throwError . FreeVariableError) <=< sdToTxt
 
@@ -169,11 +174,13 @@ pushTyName ghcName n stack = let Scope ns tyns = NE.head stack in Scope ns (Map.
 -- Types and kinds
 
 convKind :: Converting m => GHC.Kind -> m (PLC.Kind ())
-convKind k = case k of
-    -- this is a bit weird because GHC uses 'Type' to represent kinds, so '* -> *' is a 'TyFun'
-    (GHC.isStarKind -> True)              -> pure $ PLC.Type ()
-    (GHC.splitFunTy_maybe -> Just (i, o)) -> PLC.KindArrow () <$> convKind i <*> convKind o
-    _                                     -> unsupported $ "Kind:" GHC.<+> GHC.ppr k
+convKind k =
+    case k of
+        -- this is a bit weird because GHC uses 'Type' to represent kinds, so '* -> *' is a 'TyFun'
+        (GHC.isStarKind -> True)              -> pure $ PLC.Type ()
+        (GHC.splitFunTy_maybe -> Just (i, o)) -> PLC.KindArrow () <$> convKind i <*> convKind o
+        _                                     -> unsupported $ "Kind:" GHC.<+> GHC.ppr k
+    `catchError` (context $ "While converting kind:" GHC.<+> GHC.ppr k)
 
 convType :: Converting m => GHC.Type -> m PLCType
 convType t = do
@@ -190,6 +197,7 @@ convType t = do
         -- I think it's safe to ignore the coercion here
         (GHC.splitCastTy_maybe -> Just (tpe, _)) -> convType tpe
         _ -> unsupported $ "Type" GHC.<+> GHC.ppr t
+    `catchError` (context $ "While converting type:" GHC.<+> GHC.ppr t)
 
 convTyConApp :: (Converting m) => GHC.TyCon -> [GHC.Type] -> m PLCType
 convTyConApp tc ts
@@ -299,13 +307,15 @@ mkScottTyBody resultTypeName cases =
     in resultAbstracted
 
 dataConCaseType :: Converting m => PLCType -> GHC.DataCon -> m PLCType
-dataConCaseType resultType dc = if not (GHC.isVanillaDataCon dc) then unsupported $ "Non-vanilla data constructor:" GHC.<+> GHC.ppr dc else
-    do
+dataConCaseType resultType dc =
+    if not (GHC.isVanillaDataCon dc) then unsupported $ "Non-vanilla data constructor:" GHC.<+> GHC.ppr dc
+    else do
         let argTys = GHC.dataConRepArgTys dc
         args <- mapM convType argTys
         -- See Note [Iterated abstraction and application]
         -- t_1 -> ... -> t_m -> resultType
         pure $ foldr (\t acc -> PLC.TyFun () t acc) resultType args
+    `catchError` (context $ "While converting data constructor:" GHC.<+> GHC.ppr dc)
 
 -- This is the creation of the Scott-encoded constructor value.
 convConstructor :: Converting m => GHC.DataCon -> m PLCExpr
@@ -723,6 +733,7 @@ convExpr e = do
         -- ignore annotation
         GHC.Tick _ body -> convExpr body
         -- just go straight to the body, we don't care about the nominal types
-        GHC.Cast _ coerce -> unsupported $ "Unsupported: coercion" GHC.$+$ GHC.ppr coerce
+        GHC.Cast _ coerce -> unsupported $ "Coercion" GHC.$+$ GHC.ppr coerce
         GHC.Type _ -> conversionFail "Cannot convert types directly, only as arguments to applications"
         GHC.Coercion _ -> conversionFail "Coercions should not be converted"
+    `catchError` (context $ "While converting expr:" GHC.<+> GHC.ppr e)

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Error.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Error.hs
@@ -6,12 +6,20 @@ import qualified Language.PlutusCore       as PLC
 
 import qualified Data.Text                 as T
 import qualified Data.Text.Prettyprint.Doc as PP
+import           Data.Typeable
+import           GHC.Exception
 
 data Error a = PLCError (PLC.Error a)
              | ConversionError T.Text
              | UnsupportedError T.Text
              | FreeVariableError T.Text
              | Context T.Text (Error a)
+             deriving Typeable
+
+instance (PLC.PrettyCfg a) => Show (Error a) where
+    show e = T.unpack $ PLC.debugText e
+
+instance (Typeable a, PLC.PrettyCfg a) => Exception (Error a)
 
 instance (PLC.PrettyCfg a) => PLC.PrettyCfg (Error a) where
     prettyCfg cfg = \case

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Error.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Error.hs
@@ -1,23 +1,25 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
-module Language.Plutus.CoreToPLC.Error (Error (..), errorText, mustBeReplaced) where
+module Language.Plutus.CoreToPLC.Error (Error (..), mustBeReplaced) where
 
-import qualified Language.PlutusCore as PLC
+import qualified Language.PlutusCore       as PLC
 
-import           Data.Semigroup
-import qualified Data.Text           as T
+import qualified Data.Text                 as T
+import qualified Data.Text.Prettyprint.Doc as PP
 
 data Error a = PLCError (PLC.Error a)
              | ConversionError T.Text
              | UnsupportedError T.Text
              | FreeVariableError T.Text
+             | Context T.Text (Error a)
 
-errorText :: (PLC.PrettyCfg a) => Error a -> T.Text
-errorText = \case
-    PLCError e -> PLC.debugText e
-    ConversionError e -> "Error during conversion: " <> e
-    UnsupportedError e -> "Unsupported: " <> e
-    FreeVariableError e -> "Free variable: " <> e
+instance (PLC.PrettyCfg a) => PLC.PrettyCfg (Error a) where
+    prettyCfg cfg = \case
+        PLCError e -> PLC.prettyCfg cfg e
+        ConversionError e -> "Error during conversion:" PP.<+> PP.pretty e
+        UnsupportedError e -> "Unsupported:" PP.<+> PP.pretty e
+        FreeVariableError e -> "Free variable:" PP.<+> PP.pretty e
+        Context ctx e -> PP.vsep [ "Context:" PP.<+> PP.pretty ctx , PLC.prettyCfg cfg e ]
 
 mustBeReplaced :: a
 mustBeReplaced = error "This must be replaced by the core-to-plc plugin during compilation"

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Plugin.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Plugin.hs
@@ -167,7 +167,7 @@ convertExpr origE tpe = do
                 "Failed to convert GHC core expression:" GHC.$+$
                 GHC.ppr origE GHC.$+$
                 "Error is:" GHC.$+$
-                (GHC.text $ T.unpack $ errorText s)
+                (GHC.text $ T.unpack $ PLC.debugText s)
             -- this will actually terminate compilation
             liftIO $ throwIO CoreToPlcFailure
         Right (term, _) -> do


### PR DESCRIPTION
Most of this PR is the machinery that made debugging this possible!

It's worth having a special case to error out early if we see `Integer`, because it has weird constructors which give unexpected error messages. With the context added in this PR you can still see it was due to `Integer`, but I expect this to be a common case so worth some effort.