### PR TITLE
[CGP-285] Cache type conversion state and emit errors for recursion

### DIFF
--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Plugin.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Plugin.hs
@@ -19,6 +19,7 @@ import           Codec.CBOR.Read                 (DeserialiseFailure)
 import           Control.Exception
 import           Control.Monad.Except
 import           Control.Monad.Reader
+import           Control.Monad.State
 import qualified Data.ByteString.Lazy            as BSL
 import qualified Data.Map                        as Map
 import           Data.Maybe                      (catMaybes)
@@ -154,7 +155,7 @@ convertExpr origE tpe = do
               --annotated <- convertErrors PLCError $ PLC.annotateTerm converted
               --inferredType <- convertErrors PLCError $ PLC.typecheckTerm 1000 annotated
               pure (converted, undefined)
-    case runExcept $ runReaderT (runQuoteT result) (flags, primTerms, primTys, initialScopeStack) of
+    case runExcept $ runQuoteT $ evalStateT (runReaderT result (flags, primTerms, primTys, initialScopeStack)) Map.empty of
         -- TODO: should be a way to just register a compilation error with GHC
         Left s -> liftIO $ throwIO s -- this will actually terminate compilation
         Right (term, _) -> do


### PR DESCRIPTION
Annoyingly, it appears that GHC no longer tracks whether types are recursive for us (from about https://phabricator.haskell.org/D2360 onwards). This means we're going to have to track this information ourselves. This fix is therefore geared towards the expectation that we're going to be remembering information about types.

For now, we just cache all of our type conversions. This allows us to mark types as "blackholed" while we're converting them, so we can fail if we see them again. As a side benefit, it saves us some repeated work.

I have verified that this gives errors in the cases we expect. I'm working on making it easier to test cases that produce compile errors, but I'll put that up separately so we can get this in sooner.