### PR TITLE
Plugin: several improvements to error handling

### DIFF
--- a/core-to-plc/core-to-plc.cabal
+++ b/core-to-plc/core-to-plc.cabal
@@ -57,6 +57,7 @@ test-suite core-to-plc-plugin
     hs-source-dirs: test
     type: exitcode-stdio-1.0
     main-is: Spec.hs
+    other-modules: IllTyped
     build-depends:
         base >=4.9 && <5,
         core-to-plc -any,

--- a/core-to-plc/src/Language/Plutus/CoreToPLC.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC.hs
@@ -67,6 +67,8 @@ variable *last* (so it is on the outside, so will be first when applying).
 type PLCExpr = PLC.Term PLC.TyName PLC.Name ()
 type PLCType = PLC.Type PLC.TyName ()
 
+type ConvError = WithContext T.Text (Error ())
+
 type PrimTerms = Map.Map GHC.Name (Quote PLCExpr)
 type PrimTypes = Map.Map GHC.Name (Quote PLCType)
 
@@ -77,7 +79,7 @@ type TypeDefs = Map.Map GHC.Name (EvalState ())
 type ConvertingState = TypeDefs
 
 -- See Note [Scopes]
-type Converting m = (Monad m, MonadError (Error ()) m, MonadQuote m, MonadReader ConvertingContext m, MonadState ConvertingState m)
+type Converting m = (Monad m, MonadError ConvError m, MonadQuote m, MonadReader ConvertingContext m, MonadState ConvertingState m)
 
 strToBs :: String -> BSL.ByteString
 strToBs = BSL.fromStrict . TE.encodeUtf8 . T.pack
@@ -90,19 +92,14 @@ sdToTxt sd = do
   (flags, _, _, _) <- ask
   pure $ T.pack $ GHC.showSDoc flags sd
 
-conversionFail :: (MonadError (Error ()) m, MonadReader ConvertingContext m) => GHC.SDoc -> m a
-conversionFail = (throwError . ConversionError) <=< sdToTxt
+conversionFail :: (MonadError ConvError m, MonadReader ConvertingContext m) => GHC.SDoc -> m a
+conversionFail = (throwError . NoContext . ConversionError) <=< sdToTxt
 
-unsupported :: (MonadError (Error ()) m, MonadReader ConvertingContext m) => GHC.SDoc -> m a
-unsupported = (throwError . UnsupportedError) <=< sdToTxt
+unsupported :: (MonadError ConvError m, MonadReader ConvertingContext m) => GHC.SDoc -> m a
+unsupported = (throwError . NoContext . UnsupportedError) <=< sdToTxt
 
-context :: (MonadError (Error ()) m, MonadReader ConvertingContext m) => GHC.SDoc -> (Error ()) -> m a
-context sd err = do
-    txt <- sdToTxt sd
-    throwError $ Context txt err
-
-freeVariable :: (MonadError (Error ()) m, MonadReader ConvertingContext m) => GHC.SDoc -> m a
-freeVariable = (throwError . FreeVariableError) <=< sdToTxt
+freeVariable :: (MonadError ConvError m, MonadReader ConvertingContext m) => GHC.SDoc -> m a
+freeVariable = (throwError . NoContext . FreeVariableError) <=< sdToTxt
 
 -- Names and scopes
 
@@ -180,13 +177,11 @@ pushTyName ghcName n stack = let Scope ns tyns = NE.head stack in Scope ns (Map.
 -- Types and kinds
 
 convKind :: Converting m => GHC.Kind -> m (PLC.Kind ())
-convKind k =
-    case k of
-        -- this is a bit weird because GHC uses 'Type' to represent kinds, so '* -> *' is a 'TyFun'
-        (GHC.isStarKind -> True)              -> pure $ PLC.Type ()
-        (GHC.splitFunTy_maybe -> Just (i, o)) -> PLC.KindArrow () <$> convKind i <*> convKind o
-        _                                     -> unsupported $ "Kind:" GHC.<+> GHC.ppr k
-    `catchError` (context $ "While converting kind:" GHC.<+> GHC.ppr k)
+convKind k = withContextM (sdToTxt $ "Converting kind:" GHC.<+> GHC.ppr k) $ case k of
+    -- this is a bit weird because GHC uses 'Type' to represent kinds, so '* -> *' is a 'TyFun'
+    (GHC.isStarKind -> True)              -> pure $ PLC.Type ()
+    (GHC.splitFunTy_maybe -> Just (i, o)) -> PLC.KindArrow () <$> convKind i <*> convKind o
+    _                                     -> unsupported $ "Kind:" GHC.<+> GHC.ppr k
 
 -- | Try to convert a type, using the given action to convert it, and throwing an error if we have recursive evaluation.
 tryConvType :: (Converting m) => GHC.Name -> m PLCType -> m PLCType
@@ -205,7 +200,7 @@ tryConvType n act = do
             pure converted
 
 convType :: Converting m => GHC.Type -> m PLCType
-convType t = do
+convType t = withContextM (sdToTxt $ "Converting type:" GHC.<+> GHC.ppr t) $ do
     -- See Note [Scopes]
     (_, _, _, stack) <- ask
     let top = NE.head stack
@@ -219,7 +214,6 @@ convType t = do
         -- I think it's safe to ignore the coercion here
         (GHC.splitCastTy_maybe -> Just (tpe, _)) -> convType tpe
         _ -> unsupported $ "Type" GHC.<+> GHC.ppr t
-    `catchError` (context $ "While converting type:" GHC.<+> GHC.ppr t)
 
 convTyConApp :: (Converting m) => GHC.TyCon -> [GHC.Type] -> m PLCType
 convTyConApp tc ts
@@ -331,7 +325,7 @@ mkScottTyBody resultTypeName cases =
     in resultAbstracted
 
 dataConCaseType :: Converting m => PLCType -> GHC.DataCon -> m PLCType
-dataConCaseType resultType dc =
+dataConCaseType resultType dc = withContextM (sdToTxt $ "Converting data constructor:" GHC.<+> GHC.ppr dc) $
     if not (GHC.isVanillaDataCon dc) then unsupported $ "Non-vanilla data constructor:" GHC.<+> GHC.ppr dc
     else do
         let argTys = GHC.dataConRepArgTys dc
@@ -339,7 +333,6 @@ dataConCaseType resultType dc =
         -- See Note [Iterated abstraction and application]
         -- t_1 -> ... -> t_m -> resultType
         pure $ foldr (\t acc -> PLC.TyFun () t acc) resultType args
-    `catchError` (context $ "While converting data constructor:" GHC.<+> GHC.ppr dc)
 
 -- This is the creation of the Scott-encoded constructor value.
 convConstructor :: Converting m => GHC.DataCon -> m PLCExpr
@@ -657,7 +650,7 @@ into this (with a lot of noise due to our let-bindings becoming lambdas):
 -- The main function
 
 convExpr :: Converting m => GHC.CoreExpr -> m PLCExpr
-convExpr e = do
+convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
     -- See Note [Scopes]
     (_, prims, _, stack) <- ask
     let top = NE.head stack
@@ -666,24 +659,24 @@ convExpr e = do
         GHC.App (GHC.Var (isPrimitiveWrapper -> True)) arg -> convExpr arg
         -- special typeclass method calls
         GHC.App (GHC.App
-                 -- eq class method
-                 (GHC.Var n@(GHC.idDetails -> GHC.ClassOpId ((==) GHC.eqClassName . GHC.className -> True)))
-                 -- we only support applying to int
-                 (GHC.Type (GHC.eqType GHC.intTy -> True)))
+                -- eq class method
+                (GHC.Var n@(GHC.idDetails -> GHC.ClassOpId ((==) GHC.eqClassName . GHC.className -> True)))
+                -- we only support applying to int
+                (GHC.Type (GHC.eqType GHC.intTy -> True)))
             -- last arg is typeclass dictionary
             _ -> convEqMethod (GHC.varName n)
         GHC.App (GHC.App
-                 -- ord class method
-                 (GHC.Var n@(GHC.idDetails -> GHC.ClassOpId ((==) GHC.ordClassName . GHC.className -> True)))
-                 -- we only support applying to int
-                 (GHC.Type (GHC.eqType GHC.intTy -> True)))
+                -- ord class method
+                (GHC.Var n@(GHC.idDetails -> GHC.ClassOpId ((==) GHC.ordClassName . GHC.className -> True)))
+                -- we only support applying to int
+                (GHC.Type (GHC.eqType GHC.intTy -> True)))
             -- last arg is typeclass dictionary
             _ -> convOrdMethod (GHC.varName n)
         GHC.App (GHC.App
-                 -- num class method
-                 (GHC.Var n@(GHC.idDetails -> GHC.ClassOpId ((==) GHC.numClassName . GHC.className -> True)))
-                 -- we only support applying to int
-                 (GHC.Type (GHC.eqType GHC.intTy -> True)))
+                -- num class method
+                (GHC.Var n@(GHC.idDetails -> GHC.ClassOpId ((==) GHC.numClassName . GHC.className -> True)))
+                -- we only support applying to int
+                (GHC.Type (GHC.eqType GHC.intTy -> True)))
             -- last arg is typeclass dictionary
             _ -> convNumMethod (GHC.varName n)
         -- locally bound vars
@@ -760,4 +753,3 @@ convExpr e = do
         GHC.Cast _ coerce -> unsupported $ "Coercion" GHC.$+$ GHC.ppr coerce
         GHC.Type _ -> conversionFail "Cannot convert types directly, only as arguments to applications"
         GHC.Coercion _ -> conversionFail "Coercions should not be converted"
-    `catchError` (context $ "While converting expr:" GHC.<+> GHC.ppr e)

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Error.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Error.hs
@@ -49,7 +49,7 @@ instance (PLC.PrettyCfg a) => PLC.PrettyCfg (Error a) where
         PLCError e -> PLC.prettyCfg cfg e
         ConversionError e -> "Error during conversion:" PP.<+> PP.pretty e
         UnsupportedError e -> "Unsupported:" PP.<+> PP.pretty e
-        FreeVariableError e -> "Free variable:" PP.<+> PP.pretty e
+        FreeVariableError e -> "Used but not defined in the current conversion:" PP.<+> PP.pretty e
 
 mustBeReplaced :: a
 mustBeReplaced = error "This must be replaced by the core-to-plc plugin during compilation"

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Error.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Error.hs
@@ -1,25 +1,48 @@
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
-module Language.Plutus.CoreToPLC.Error (Error (..), mustBeReplaced) where
+module Language.Plutus.CoreToPLC.Error (
+    Error (..)
+    , WithContext (..)
+    , withContext
+    , withContextM
+    , mustBeReplaced) where
 
 import qualified Language.PlutusCore       as PLC
 
+import           Control.Monad.Except
 import qualified Data.Text                 as T
 import qualified Data.Text.Prettyprint.Doc as PP
 import           Data.Typeable
-import           GHC.Exception
+
+-- | An error with some (nested) context.
+data WithContext c e = NoContext e | WithContext c (WithContext c e)
+    deriving Functor
+
+withContext :: (MonadError (WithContext c e) m) => c -> m a -> m a
+withContext c act = catchError act $ \err -> throwError (WithContext c err)
+
+withContextM :: (MonadError (WithContext c e) m) => m c -> m a -> m a
+withContextM mc act = do
+    c <- mc
+    catchError act $ \err -> throwError (WithContext c err)
+
+instance (PP.Pretty c, PP.Pretty e) => PP.Pretty (WithContext c e) where
+    pretty = \case
+        NoContext e     -> "Error:" PP.<+> (PP.align $ PP.pretty e)
+        WithContext c e -> PP.vsep [
+            PP.pretty e,
+            "Context:" PP.<+> (PP.align $ PP.pretty c)
+            ]
 
 data Error a = PLCError (PLC.Error a)
              | ConversionError T.Text
              | UnsupportedError T.Text
              | FreeVariableError T.Text
-             | Context T.Text (Error a)
              deriving Typeable
 
-instance (PLC.PrettyCfg a) => Show (Error a) where
-    show e = T.unpack $ PLC.debugText e
-
-instance (Typeable a, PLC.PrettyCfg a) => Exception (Error a)
+instance (PLC.PrettyCfg a) => PP.Pretty (Error a) where
+    pretty = PLC.prettyCfg PLC.debugCfg
 
 instance (PLC.PrettyCfg a) => PLC.PrettyCfg (Error a) where
     prettyCfg cfg = \case
@@ -27,7 +50,6 @@ instance (PLC.PrettyCfg a) => PLC.PrettyCfg (Error a) where
         ConversionError e -> "Error during conversion:" PP.<+> PP.pretty e
         UnsupportedError e -> "Unsupported:" PP.<+> PP.pretty e
         FreeVariableError e -> "Free variable:" PP.<+> PP.pretty e
-        Context ctx e -> PP.vsep [ "Context:" PP.<+> PP.pretty ctx , PLC.prettyCfg cfg e ]
 
 mustBeReplaced :: a
 mustBeReplaced = error "This must be replaced by the core-to-plc plugin during compilation"

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Plugin.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Plugin.hs
@@ -9,6 +9,7 @@ import           Language.Plutus.CoreToPLC
 import           Language.Plutus.CoreToPLC.Error
 
 import qualified GhcPlugins                      as GHC
+import qualified Panic                           as GHC
 
 import qualified Language.PlutusCore             as PLC
 import           Language.PlutusCore.Quote
@@ -162,8 +163,7 @@ convertExpr opts origE tpe = do
                   void $ convertErrors PLCError $ PLC.typecheckTerm 1000 annotated
               pure converted
     case runExcept $ runQuoteT $ evalStateT (runReaderT result (flags, primTerms, primTys, initialScopeStack)) Map.empty of
-        -- TODO: should be a way to just register a compilation error with GHC
-        Left s -> liftIO $ throwIO s -- this will actually terminate compilation
+        Left s -> liftIO $ GHC.throwGhcExceptionIO (GHC.ProgramError (show s)) -- this will actually terminate compilation
         Right term -> do
             let termRep = T.unpack $ PLC.debugText term
             -- Note: tests run with --verbose, so these will appear

--- a/core-to-plc/test/IllTyped.hs
+++ b/core-to-plc/test/IllTyped.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS -fplugin Language.Plutus.CoreToPLC.Plugin -fplugin-opt Language.Plutus.CoreToPLC.Plugin:dont-typecheck #-}
+-- the simplfiier messes with things otherwise
+{-# OPTIONS_GHC   -O0 #-}
+
+-- | Terms which currently fail the typechecker, but which should work in future.
+-- In a separate file so we can give different options to the plugin.
+module IllTyped where
+
+import           Language.Plutus.CoreToPLC.Plugin
+import           Language.Plutus.CoreToPLC.Primitives as Prims
+
+blocknumPlc :: PlcCode
+blocknumPlc = plc Prims.blocknum
+
+bytestring :: PlcCode
+bytestring = plc (\(x::Prims.ByteString) -> x)
+
+verify :: PlcCode
+verify = plc (\(x::Prims.ByteString) (y::Prims.ByteString) (z::Prims.ByteString) -> Prims.verifySignature x y z)
+
+tupleMatch :: PlcCode
+tupleMatch = plc (\(x:: (Int, Int)) -> let (a, b) = x in a)

--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -189,6 +189,7 @@ errors :: TestTree
 errors = testGroup "Errors" [
     golden "integer" integer
     , golden "free" free
+    , golden "list" list
   ]
 
 integer :: PlcCode
@@ -196,3 +197,6 @@ integer = plc (1::Integer)
 
 free :: PlcCode
 free = plc (True && False)
+
+list :: PlcCode
+list = plc ([(1::Int)])

--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
-{-# OPTIONS -fplugin=Language.Plutus.CoreToPLC.Plugin #-}
+{-# OPTIONS -fplugin Language.Plutus.CoreToPLC.Plugin #-}
 -- the simplfiier messes with things otherwise
 {-# OPTIONS_GHC   -O0 #-}
 
 module Main (main) where
+
+import IllTyped
 
 import           Language.Plutus.CoreToPLC.Plugin
 import           Language.Plutus.CoreToPLC.Primitives as Prims
@@ -72,9 +74,6 @@ bool = plc True
 tuple :: PlcCode
 tuple = plc ((1::Int), (2::Int))
 
-tupleMatch :: PlcCode
-tupleMatch = plc (\(x:: (Int, Int)) -> let (a, b) = x in a)
-
 intCompare :: PlcCode
 intCompare = plc (\(x::Int) (y::Int) -> x < y)
 
@@ -86,15 +85,6 @@ intPlus = plc (\(x::Int) (y::Int) -> x + y)
 
 errorPlc :: PlcCode
 errorPlc = plc (Prims.error @Int)
-
-blocknumPlc :: PlcCode
-blocknumPlc = plc Prims.blocknum
-
-bytestring :: PlcCode
-bytestring = plc (\(x::Prims.ByteString) -> x)
-
-verify :: PlcCode
-verify = plc (\(x::Prims.ByteString) (y::Prims.ByteString) (z::Prims.ByteString) -> Prims.verifySignature x y z)
 
 structure :: TestTree
 structure = testGroup "Structures" [

--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -40,6 +40,7 @@ tests = testGroup "GHC Core to PLC conversion" [
   , structure
   , datat
   , recursion
+  , errors
   ]
 
 basic :: TestTree
@@ -58,7 +59,6 @@ primitives :: TestTree
 primitives = testGroup "Primitive types and operations" [
     golden "string" string
   , golden "int" int
-  , golden "integer" integer
   , golden "bool" bool
   , golden "tuple" tuple
   , golden "tupleMatch" tupleMatch
@@ -76,9 +76,6 @@ string = plc "test"
 
 int :: PlcCode
 int = plc (1::Int)
-
-integer :: PlcCode
-integer = plc (1::Integer)
 
 bool :: PlcCode
 bool = plc True
@@ -187,3 +184,15 @@ fib :: PlcCode
 fib = plc (let fib :: Int -> Int
                fib n = if n == 0 then 0 else if n == 1 then 1 else fib(n-1) + fib(n-2)
            in fib 4)
+
+errors :: TestTree
+errors = testGroup "Errors" [
+    golden "integer" integer
+    , golden "free" free
+  ]
+
+integer :: PlcCode
+integer = plc (1::Integer)
+
+free :: PlcCode
+free = plc (True && False)

--- a/core-to-plc/test/free.plc.golden
+++ b/core-to-plc/test/free.plc.golden
@@ -1,0 +1,4 @@
+Error: Used but not defined in the current conversion: Variable: &&
+Context: Converting expr: &&
+Context: Converting expr: && True
+Context: Converting expr: && True False

--- a/core-to-plc/test/integer.plc.golden
+++ b/core-to-plc/test/integer.plc.golden
@@ -1,0 +1,2 @@
+Error: Unsupported: Literal (unbounded) integer
+Context: Converting expr: 1

--- a/core-to-plc/test/list.plc.golden
+++ b/core-to-plc/test/list.plc.golden
@@ -1,0 +1,9 @@
+Error: Error during conversion: Recursion while converting types
+Context: Converting type: [a]
+Context: Converting data constructor: :
+Context: Converting type: [a]
+Context: Converting data constructor: :
+Context: Converting expr: :
+Context: Converting expr: : @ Int
+Context: Converting expr: : @ Int (I# 1#)
+Context: Converting expr: : @ Int (I# 1#) ([] @ Int)


### PR DESCRIPTION
- Typecheck things that we are able to.
    - I added an option to disable typechecking, and put the things that don't typecheck in a separate module with that option on, so at least we can typecheck the things that work.
- Throw `GhcException` instead of our own exception.
- Slightly nicer error contexts.
- Allow deferring plugin errors to runtime.
    - This means the value will blow up with the error as an exception when you touch it. This is only really useful for testing, but it's quite useful there! I added a test to demonstrate.