### PR TITLE
[CGP-296] Support Void# and void#

### DIFF
--- a/core-to-plc/test/IllTyped.hs
+++ b/core-to-plc/test/IllTyped.hs
@@ -21,3 +21,7 @@ verify = plc (\(x::Prims.ByteString) (y::Prims.ByteString) (z::Prims.ByteString)
 
 tupleMatch :: PlcCode
 tupleMatch = plc (\(x:: (Int, Int)) -> let (a, b) = x in a)
+
+-- Has a Void in it
+void :: PlcCode
+void = plc (\(x::Int) (y::Int) -> let a x' y' = case (x', y') of { (True, True) -> True; _ -> False; } in (x == y) `a` (y == x))

--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -64,6 +64,7 @@ primitives = testGroup "Primitive types and operations" [
   , golden "tupleMatch" tupleMatch
   , golden "intCompare" intCompare
   , golden "intEq" intEq
+  , golden "void" void
   , golden "intPlus" intPlus
   , golden "error" errorPlc
   , golden "blocknum" blocknumPlc

--- a/core-to-plc/test/void.plc.golden
+++ b/core-to-plc/test/void.plc.golden
@@ -1,0 +1,108 @@
+(program 1.0.0
+  (lam
+    ds_0
+    [(con integer) (con 64)]
+    (lam
+      ds_1
+      [(con integer) (con 64)]
+      [
+        (lam
+          eta_3
+          (all Bool_matchOut_2 (type) (fun Bool_matchOut_2 (fun Bool_matchOut_2 Bool_matchOut_2)))
+          [
+            (lam
+              eta_5
+              (all Bool_matchOut_4 (type) (fun Bool_matchOut_4 (fun Bool_matchOut_4 Bool_matchOut_4)))
+              [
+                [
+                  (lam
+                    x_7
+                    (all Bool_matchOut_6 (type) (fun Bool_matchOut_6 (fun Bool_matchOut_6 Bool_matchOut_6)))
+                    (lam
+                      y_9
+                      (all Bool_matchOut_8 (type) (fun Bool_matchOut_8 (fun Bool_matchOut_8 Bool_matchOut_8)))
+                      [
+                        (lam
+                          fail_17
+                          (fun (all any_15 (type) any_15) (all Bool_matchOut_16 (type) (fun Bool_matchOut_16 (fun Bool_matchOut_16 Bool_matchOut_16))))
+                          [
+                            [
+                              [
+                                {
+                                  x_7
+                                  (fun (all a_19 (type) (fun a_19 a_19)) (all Bool_matchOut_18 (type) (fun Bool_matchOut_18 (fun Bool_matchOut_18 Bool_matchOut_18))))
+                                }
+                                (lam
+                                  thunk_21
+                                  (all a_22 (type) (fun a_22 a_22))
+                                  [ fail_17 (abs e_20 (type) (error e_20)) ]
+                                )
+                              ]
+                              (lam
+                                thunk_35
+                                (all a_36 (type) (fun a_36 a_36))
+                                [
+                                  [
+                                    [
+                                      {
+                                        y_9
+                                        (fun (all a_24 (type) (fun a_24 a_24)) (all Bool_matchOut_23 (type) (fun Bool_matchOut_23 (fun Bool_matchOut_23 Bool_matchOut_23))))
+                                      }
+                                      (lam
+                                        thunk_26
+                                        (all a_27 (type) (fun a_27 a_27))
+                                        [
+                                          fail_17 (abs e_25 (type) (error e_25))
+                                        ]
+                                      )
+                                    ]
+                                    (lam
+                                      thunk_31
+                                      (all a_32 (type) (fun a_32 a_32))
+                                      (abs
+                                        Bool_matchOut_28
+                                        (type)
+                                        (lam
+                                          False_29
+                                          Bool_matchOut_28
+                                          (lam True_30 Bool_matchOut_28 True_30)
+                                        )
+                                      )
+                                    )
+                                  ]
+                                  (abs a_33 (type) (lam x_34 a_33 x_34))
+                                ]
+                              )
+                            ]
+                            (abs a_37 (type) (lam x_38 a_37 x_38))
+                          ]
+                        )
+                        (lam
+                          ds_11
+                          (all any_10 (type) any_10)
+                          (abs
+                            Bool_matchOut_12
+                            (type)
+                            (lam
+                              False_13
+                              Bool_matchOut_12
+                              (lam True_14 Bool_matchOut_12 False_13)
+                            )
+                          )
+                        )
+                      ]
+                    )
+                  )
+                  eta_3
+                ]
+                eta_5
+              ]
+            )
+            [ [ { (con equalsInteger) (con 64) } ds_1 ] ds_0 ]
+          ]
+        )
+        [ [ { (con equalsInteger) (con 64) } ds_0 ] ds_1 ]
+      ]
+    )
+  )
+)


### PR DESCRIPTION
These are the uninhabited type and an inhabitant for that type (to use
in unreachable cases).

In Plutus we can represent `Void#` as `(all a (type) a)`, which is
uninhabited, and then fortunately we can actually create a value to put
there, namely `(abs a (type) (error a))`.