### PR TITLE
Keep annotations while type checking

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -148,7 +148,7 @@ parseScoped :: (MonadError (Error AlexPosn) m) => BSL.ByteString -> m (Program T
 parseScoped str = liftEither $ convertError $ fmap (\(p, s) -> rename s p) $ runExcept $ runStateT (parseST str) emptyIdentifierState
 
 -- | Parse a program and typecheck it.
-parseTypecheck :: (MonadError (Error AlexPosn) m, MonadQuote m) => Natural -> BSL.ByteString -> m (NormalizedType TyNameWithKind ())
+parseTypecheck :: (MonadError (Error AlexPosn) m, MonadQuote m) => Natural -> BSL.ByteString -> m (NormalizedType TyNameWithKind AlexPosn)
 parseTypecheck gas bs = do
     parsed <- parseProgram bs
     checkProgram parsed

--- a/language-plutus-core/src/Language/PlutusCore/Error.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Error.hs
@@ -38,8 +38,8 @@ instance (PrettyCfg a) => PrettyCfg (RenameError a) where
     prettyCfg cfg (UnboundTyVar n@(TyName (Name loc _ _))) = "Error at" <+> prettyCfg cfg loc <> ". Type variable" <+> prettyCfg cfg n <+> "is not in scope."
 
 data TypeError a = InternalError -- ^ This is thrown if builtin lookup fails
-                 | KindMismatch a (Type TyNameWithKind ()) (Kind ()) (Kind ())
-                 | TypeMismatch a (Term TyNameWithKind NameWithType ()) (Type TyNameWithKind ()) (NormalizedType TyNameWithKind ())
+                 | KindMismatch a (Type TyNameWithKind a) (Kind a) (Kind a)
+                 | TypeMismatch a (Term TyNameWithKind NameWithType a) (Type TyNameWithKind a) (NormalizedType TyNameWithKind a)
                  | OutOfGas
                  deriving (Show, Eq, Generic, NFData)
 


### PR DESCRIPTION
We have

```haskell
data TypeError a = InternalError -- ^ This is thrown if builtin lookup fails
                 | KindMismatch a (Type TyNameWithKind ()) (Kind ()) (Kind ())
                 | TypeMismatch a (Term TyNameWithKind NameWithType ()) (Type TyNameWithKind ()) (NormalizedType TyNameWithKind ())
                 | OutOfGas
deriving (Show, Eq, Generic, NFData)
```

but that is inconsistent with how we usually deal with annotations: they're propagated further into what is stored in constructors. And I needed that latter representation, so I changed `TypeError` to 

```haskell
data TypeError a = InternalError -- ^ This is thrown if builtin lookup fails
                 | KindMismatch a (Type TyNameWithKind a) (Kind a) (Kind a)
                 | TypeMismatch a (Term TyNameWithKind NameWithType a) (Type TyNameWithKind a) (NormalizedType TyNameWithKind a)
                 | OutOfGas
                 deriving (Show, Eq, Generic, NFData)
```

and updated the `TypeSynthesis` module to preserve annotations. This all is straightforward except we have things like

```haskell
kindOf (TyBuiltin x b) = do
    (BuiltinTable tyst _) <- ask
    case M.lookup b tyst of
        Just k -> pure $ x <$ k
...
typeOf (Constant x (BuiltinName _ n)) = do
    (BuiltinTable _ st) <- ask
    case M.lookup n st of
        Just k -> pure $ x <$ k
```

i.e. the inferred kind/type of a built-in is annotated with the same thing the built-in is annotated with.

Later I realized that I it's not necessary for me to have annotations propagated in the `TypeError`, but I think it's a fine change anyway.