### PR TITLE
core-to-plc: handle the value restriction

### DIFF
--- a/core-to-plc/src/Language/Plutus/CoreToPLC.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC.hs
@@ -95,17 +95,8 @@ sdToTxt sd = do
   (flags, _, _, _) <- ask
   pure $ T.pack $ GHC.showSDoc flags sd
 
-conversionFail :: (MonadError ConvError m, MonadReader ConvertingContext m) => GHC.SDoc -> m a
-conversionFail = (throwError . NoContext . ConversionError) <=< sdToTxt
-
-unsupported :: (MonadError ConvError m, MonadReader ConvertingContext m) => GHC.SDoc -> m a
-unsupported = (throwError . NoContext . UnsupportedError) <=< sdToTxt
-
-valueRestriction :: (MonadError ConvError m, MonadReader ConvertingContext m) => GHC.SDoc -> m a
-valueRestriction = (throwError . NoContext . ValueRestrictionError) <=< sdToTxt
-
-freeVariable :: (MonadError ConvError m, MonadReader ConvertingContext m) => GHC.SDoc -> m a
-freeVariable = (throwError . NoContext . FreeVariableError) <=< sdToTxt
+throwSd :: (MonadError ConvError m, MonadReader ConvertingContext m) => (T.Text -> Error ()) -> GHC.SDoc -> m a
+throwSd constr = (throwPlain . constr) <=< sdToTxt
 
 -- Names and scopes
 
@@ -187,14 +178,14 @@ convKind k = withContextM (sdToTxt $ "Converting kind:" GHC.<+> GHC.ppr k) $ cas
     -- this is a bit weird because GHC uses 'Type' to represent kinds, so '* -> *' is a 'TyFun'
     (GHC.isStarKind -> True)              -> pure $ PLC.Type ()
     (GHC.splitFunTy_maybe -> Just (i, o)) -> PLC.KindArrow () <$> convKind i <*> convKind o
-    _                                     -> unsupported $ "Kind:" GHC.<+> GHC.ppr k
+    _                                     -> throwSd UnsupportedError $ "Kind:" GHC.<+> GHC.ppr k
 
 -- | Try to convert a type, using the given action to convert it, and throwing an error if we have recursive evaluation.
 tryConvType :: (Converting m) => GHC.Name -> m PLCType -> m PLCType
 tryConvType n act = do
     tds <- get
     case Map.lookup n tds of
-        Just Blackhole -> conversionFail "Recursion while converting types"
+        Just Blackhole -> throwPlain $ ConversionError "Recursion while converting types"
         -- Either already seen and done or not seen.
         -- Ideally we would store the finished type, but we actually need to
         -- store a version in Quote so we can recreate it safely in multiple
@@ -213,13 +204,13 @@ convType t = withContextM (sdToTxt $ "Converting type:" GHC.<+> GHC.ppr t) $ do
     case t of
         -- in scope type name
         (GHC.getTyVar_maybe -> Just (lookupTyName top . GHC.varName -> Just name)) -> pure $ PLC.TyVar () name
-        (GHC.getTyVar_maybe -> Just v) -> freeVariable $ "Type variable:" GHC.<+> GHC.ppr v
+        (GHC.getTyVar_maybe -> Just v) -> throwSd FreeVariableError $ "Type variable:" GHC.<+> GHC.ppr v
         (GHC.splitFunTy_maybe -> Just (i, o)) -> PLC.TyFun () <$> convType i <*> convType o
         (GHC.splitTyConApp_maybe -> Just (tc, ts)) -> convTyConApp tc ts
         (GHC.splitForAllTy_maybe -> Just (tv, tpe)) -> mkTyForall tv (convType tpe)
         -- I think it's safe to ignore the coercion here
         (GHC.splitCastTy_maybe -> Just (tpe, _)) -> convType tpe
-        _ -> unsupported $ "Type" GHC.<+> GHC.ppr t
+        _ -> throwSd UnsupportedError $ "Type" GHC.<+> GHC.ppr t
 
 convTyConApp :: (Converting m) => GHC.TyCon -> [GHC.Type] -> m PLCType
 convTyConApp tc ts
@@ -228,7 +219,7 @@ convTyConApp tc ts
     -- this is Int#
     | tc == GHC.intPrimTyCon = pure $ appSize haskellIntSize (PLC.TyBuiltin () PLC.TyInteger)
     -- we don't support Integer
-    | GHC.tyConName tc == GHC.integerTyConName = unsupported "Integer: use Int instead"
+    | GHC.tyConName tc == GHC.integerTyConName = throwPlain $ UnsupportedError "Integer: use Int instead"
     -- this is Void#, see Note [Value restriction]
     | tc == GHC.voidPrimTyCon = do
           tyname <- safeFreshTyName "a"
@@ -317,12 +308,12 @@ a unit argument and apply it at the end.
 getDataCons :: (Converting m) =>  GHC.TyCon -> m [GHC.DataCon]
 getDataCons tc
     | GHC.isAlgTyCon tc || GHC.isTupleTyCon tc = case GHC.algTyConRhs tc of
-        GHC.AbstractTyCon                -> unsupported $ "Abstract type:" GHC.<+> GHC.ppr tc
+        GHC.AbstractTyCon                -> throwSd UnsupportedError $ "Abstract type:" GHC.<+> GHC.ppr tc
         GHC.DataTyCon{GHC.data_cons=dcs} -> pure dcs
         GHC.TupleTyCon{GHC.data_con=dc}  -> pure [dc]
         GHC.SumTyCon{GHC.data_cons=dcs}  -> pure dcs
         GHC.NewTyCon{GHC.data_con=dc}    -> pure [dc]
-    | otherwise = unsupported $ "Type constructor:" GHC.<+> GHC.ppr tc
+    | otherwise = throwSd UnsupportedError $ "Type constructor:" GHC.<+> GHC.ppr tc
 
 -- This is the creation of the Scott-encoded datatype type. See Note [Scott encoding of datatypes]
 convDataCons :: forall m. Converting m => GHC.TyCon -> [GHC.DataCon] -> m PLCType
@@ -347,7 +338,7 @@ mkScottTyBody resultTypeName cases =
 
 dataConCaseType :: Converting m => PLCType -> GHC.DataCon -> m PLCType
 dataConCaseType resultType dc = withContextM (sdToTxt $ "Converting data constructor:" GHC.<+> GHC.ppr dc) $
-    if not (GHC.isVanillaDataCon dc) then unsupported $ "Non-vanilla data constructor:" GHC.<+> GHC.ppr dc
+    if not (GHC.isVanillaDataCon dc) then throwSd UnsupportedError $ "Non-vanilla data constructor:" GHC.<+> GHC.ppr dc
     else do
         let argTys = GHC.dataConRepArgTys dc
         args <- mapM convType argTys
@@ -371,7 +362,7 @@ convConstructor dc =
             dcs <- getDataCons tc
             index <- case elemIndex dc dcs of
                 Just i  -> pure i
-                Nothing -> conversionFail "Data constructor not in the type constructor's list of constructors!"
+                Nothing -> throwPlain $ ConversionError "Data constructor not in the type constructor's list of constructors!"
             caseTypes <- mapM (dataConCaseType (PLC.TyVar () resultType)) dcs
             caseArgNames <- mapM (convNameFresh . GHC.dataConName) dcs
             argTypes <- mapM convType $ GHC.dataConRepArgTys dc
@@ -398,7 +389,7 @@ mkScottConstructorBody resultTypeName caseNamesAndTypes argNamesAndTypes index =
 
 convAlt :: Converting m => GHC.CoreAlt -> m PLCExpr
 convAlt (alt, vars, body) = case alt of
-    GHC.LitAlt _  -> unsupported "Literal case"
+    GHC.LitAlt _  -> throwPlain $ UnsupportedError "Literal case"
     GHC.DEFAULT   -> do
         caseBody <- convExpr body
         delay caseBody
@@ -423,14 +414,14 @@ convLiteral l = case l of
     GHC.MachInt64 i    -> pure $ PLC.BuiltinInt () haskellIntSize i
     GHC.MachInt i      -> pure $ PLC.BuiltinInt () haskellIntSize i
     GHC.MachStr bs     -> pure $ PLC.BuiltinBS () haskellBSSize (BSL.fromStrict bs)
-    GHC.LitInteger _ _ -> unsupported "Literal (unbounded) integer"
-    GHC.MachWord _     -> unsupported "Literal word"
-    GHC.MachWord64 _   -> unsupported "Literal word64"
-    GHC.MachChar _     -> unsupported "Literal char"
-    GHC.MachFloat _    -> unsupported "Literal float"
-    GHC.MachDouble _   -> unsupported "Literal double"
-    GHC.MachLabel {}   -> unsupported "Literal label"
-    GHC.MachNullAddr   -> unsupported "Literal null"
+    GHC.LitInteger _ _ -> throwPlain $ UnsupportedError "Literal (unbounded) integer"
+    GHC.MachWord _     -> throwPlain $ UnsupportedError "Literal word"
+    GHC.MachWord64 _   -> throwPlain $ UnsupportedError "Literal word64"
+    GHC.MachChar _     -> throwPlain $ UnsupportedError "Literal char"
+    GHC.MachFloat _    -> throwPlain $ UnsupportedError "Literal float"
+    GHC.MachDouble _   -> throwPlain $ UnsupportedError "Literal double"
+    GHC.MachLabel {}   -> throwPlain $ UnsupportedError "Literal label"
+    GHC.MachNullAddr   -> throwPlain $ UnsupportedError "Literal null"
 
 isPrimitiveWrapper :: GHC.Id -> Bool
 isPrimitiveWrapper i = case GHC.idDetails i of
@@ -456,7 +447,7 @@ convPrimitiveOp po = do
         GHC.IntLtOp   -> pure PLC.LessThanInteger
         GHC.IntLeOp   -> pure PLC.LessThanEqInteger
         GHC.IntEqOp   -> pure PLC.EqInteger
-        _             -> unsupported $ "Primitive operation:" GHC.<+> GHC.ppr po
+        _             -> throwSd UnsupportedError $ "Primitive operation:" GHC.<+> GHC.ppr po
     pure $ instSize haskellIntSize (mkConstant name)
 
 -- Typeclasses
@@ -468,7 +459,7 @@ convEqMethod name = do
         where
             method n
               | n == GHC.eqName = pure PLC.EqInteger
-              | otherwise = unsupported $ "Eq method:" GHC.<+> GHC.ppr n
+              | otherwise = throwSd UnsupportedError $ "Eq method:" GHC.<+> GHC.ppr n
 
 convOrdMethod :: (Converting m) => GHC.Name -> m PLCExpr
 convOrdMethod name = do
@@ -481,7 +472,7 @@ convOrdMethod name = do
                 | GHC.getOccString n == ">" = pure PLC.GreaterThanInteger
                 | GHC.getOccString n == "<=" = pure PLC.LessThanEqInteger
                 | GHC.getOccString n == "<" = pure PLC.LessThanInteger
-                | otherwise = unsupported $ "Ord method:" GHC.<+> GHC.ppr n
+                | otherwise = throwSd UnsupportedError $ "Ord method:" GHC.<+> GHC.ppr n
 
 convNumMethod :: (Converting m) => GHC.Name -> m PLCExpr
 convNumMethod name = do
@@ -493,7 +484,7 @@ convNumMethod name = do
                 | n == GHC.minusName = pure PLC.SubtractInteger
                 | GHC.getOccString n == "+" = pure PLC.AddInteger
                 | GHC.getOccString n == "*" = pure PLC.MultiplyInteger
-                | otherwise = unsupported $ "Num method:" GHC.<+> GHC.ppr n
+                | otherwise = throwSd UnsupportedError $ "Num method:" GHC.<+> GHC.ppr n
 
 -- Plutus primitives
 
@@ -625,7 +616,7 @@ mkTyAbs v body = do
     let ghcName = GHC.tyVarName v
     (k', t') <- convTyVarFresh v
     body' <- local (second $ pushTyName ghcName t') body
-    unless (PLC.isTermValue body') $ valueRestriction "Type abstraction body is not a value"
+    unless (PLC.isTermValue body') $ throwPlain $ ValueRestrictionError "Type abstraction body is not a value"
     pure $ PLC.TyAbs () t' k' body'
 
 -- | Builds a forall, binding the given variable to a name that
@@ -795,8 +786,8 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
         GHC.Var (flip Map.lookup prims . GHC.varName -> Just term) -> liftQuote term
         -- the term we get must be closed - we don't resolve most references
         -- TODO: possibly relax this?
-        GHC.Var n@(GHC.idDetails -> GHC.VanillaId) -> freeVariable $ "Variable:" GHC.<+> GHC.ppr n GHC.$+$ (GHC.ppr $ GHC.idDetails n)
-        GHC.Var n -> unsupported $ "Variable" GHC.<+> GHC.ppr n GHC.$+$ (GHC.ppr $ GHC.idDetails n)
+        GHC.Var n@(GHC.idDetails -> GHC.VanillaId) -> throwSd FreeVariableError $ "Variable:" GHC.<+> GHC.ppr n GHC.$+$ (GHC.ppr $ GHC.idDetails n)
+        GHC.Var n -> throwSd UnsupportedError $ "Variable" GHC.<+> GHC.ppr n GHC.$+$ (GHC.ppr $ GHC.idDetails n)
         GHC.Lit lit -> PLC.Constant () <$> convLiteral lit
         -- arg can be a type here, in which case it's a type instantiation
         GHC.App l (GHC.Type t) -> PLC.TyInst () <$> convExpr l <*> convType t
@@ -815,7 +806,7 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
             tys <- mapM convType (fmap (GHC.varType . fst) bs)
             forM_ tys $ \case
                 PLC.TyFun {} -> pure ()
-                _ -> conversionFail "Recursive values must be of function type. You may need to manually add unit arguments."
+                _ -> throwPlain $ ConversionError "Recursive values must be of function type. You may need to manually add unit arguments."
             tupleTy <- mkTupleType tys
 
             bsLam <- flip (foldr (\b acc -> mkLambda b acc)) (fmap fst bs) $ do
@@ -835,7 +826,7 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
             -- must be a TC app
             tc <- case GHC.splitTyConApp_maybe scrutineeType of
                 Just (tc, _) -> pure tc
-                Nothing      -> conversionFail "Scrutinee's type was not a type constructor application"
+                Nothing      -> throwPlain $ ConversionError "Scrutinee's type was not a type constructor application"
             dcs <- getDataCons tc
             -- See Note [Scott encoding of datatypes]
             -- we're going to delay the body, so the scrutinee needs to be instantiated the delayed type
@@ -851,7 +842,7 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
                         pure $ foldr (\(n', t') acc -> PLC.LamAbs () n' t' acc) alt' (zip argNames argTypes)
                     else
                         pure alt'
-                Nothing -> conversionFail "No case matched and no default case"
+                Nothing -> throwPlain $ ConversionError "No case matched and no default case"
             -- See Note [Iterated abstraction and application]
             -- See Note [Case expressions and laziness]
             force $ foldl' (\acc alt -> PLC.Apply () acc alt) instantiated branches
@@ -875,6 +866,6 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
                     name <- safeFreshName "c"
                     -- no need for a body value check here, we know it's a lambda (see Note [Value restriction])
                     pure $ PLC.TyAbs () tyName (PLC.Type ()) $ PLC.LamAbs () name (PLC.TyFun () inner' (PLC.TyVar () tyName)) $ PLC.Apply () (PLC.Var () name) body'
-                _ -> unsupported $ "Coercion" GHC.$+$ GHC.ppr coerce
-        GHC.Type _ -> conversionFail "Cannot convert types directly, only as arguments to applications"
-        GHC.Coercion _ -> conversionFail "Coercions should not be converted"
+                _ -> throwSd UnsupportedError $ "Coercion" GHC.$+$ GHC.ppr coerce
+        GHC.Type _ -> throwPlain $ ConversionError "Cannot convert types directly, only as arguments to applications"
+        GHC.Coercion _ -> throwPlain $ ConversionError "Coercions should not be converted"

--- a/core-to-plc/src/Language/Plutus/CoreToPLC.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC.hs
@@ -221,9 +221,7 @@ convTyConApp tc ts
     -- we don't support Integer
     | GHC.tyConName tc == GHC.integerTyConName = throwPlain $ UnsupportedError "Integer: use Int instead"
     -- this is Void#, see Note [Value restriction]
-    | tc == GHC.voidPrimTyCon = do
-          tyname <- safeFreshTyName "a"
-          mangleTyForall $ PLC.TyForall () tyname (PLC.Type ()) (PLC.TyVar () tyname)
+    | tc == GHC.voidPrimTyCon = liftQuote errorTy
     | otherwise = do
         tc' <- convTyCon tc
         args' <- mapM convType ts
@@ -522,6 +520,12 @@ errorFunc = do
     n <- freshTyName () "e"
     -- see Note [Value restriction]
     mangleTyAbs $ PLC.TyAbs () n (PLC.Type ()) (PLC.Error () (PLC.TyVar () n))
+
+-- | The type 'forall a. () -> a'.
+errorTy :: Quote (PLC.Type PLC.TyName ())
+errorTy = do
+    tyname <- safeFreshTyName "a"
+    mangleTyForall $ PLC.TyForall () tyname (PLC.Type ()) (PLC.TyVar () tyname)
 
 -- Value restriction
 

--- a/core-to-plc/src/Language/Plutus/CoreToPLC.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC.hs
@@ -533,7 +533,8 @@ errorTy = do
 Plutus Core has the traditional *value restriction* on type abstractions - namely, the
 body of a type abstraction must be a value.
 
-This causes problems for us because *Haskell* has no such thing.
+This causes problems for us because *Haskell* has no such thing. (There is the monomorphism
+restriciton, which is similar, but not as restrictive, so it doesn't help us.)
 
 There are two approaches to solving this problem. Currently we use "passing on the value restriction",
 but I include a description of mangling to illustrate why the current solution is preferable.

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Error.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Error.hs
@@ -6,6 +6,7 @@ module Language.Plutus.CoreToPLC.Error (
     , WithContext (..)
     , withContext
     , withContextM
+    , throwPlain
     , mustBeReplaced) where
 
 import qualified Language.PlutusCore       as PLC
@@ -26,6 +27,9 @@ withContextM :: (MonadError (WithContext c e) m) => m c -> m a -> m a
 withContextM mc act = do
     c <- mc
     catchError act $ \err -> throwError (WithContext c err)
+
+throwPlain :: MonadError (WithContext c e) m => e -> m a
+throwPlain = throwError . NoContext
 
 instance (PP.Pretty c, PP.Pretty e) => PP.Pretty (WithContext c e) where
     pretty = \case

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Error.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Error.hs
@@ -39,6 +39,7 @@ data Error a = PLCError (PLC.Error a)
              | ConversionError T.Text
              | UnsupportedError T.Text
              | FreeVariableError T.Text
+             | ValueRestrictionError T.Text
              deriving Typeable
 
 instance (PLC.PrettyCfg a) => PP.Pretty (Error a) where
@@ -50,6 +51,7 @@ instance (PLC.PrettyCfg a) => PLC.PrettyCfg (Error a) where
         ConversionError e -> "Error during conversion:" PP.<+> PP.pretty e
         UnsupportedError e -> "Unsupported:" PP.<+> PP.pretty e
         FreeVariableError e -> "Used but not defined in the current conversion:" PP.<+> PP.pretty e
+        ValueRestrictionError e -> "Violation of the value restriction:" PP.<+> PP.pretty e
 
 mustBeReplaced :: a
 mustBeReplaced = error "This must be replaced by the core-to-plc plugin during compilation"

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Primitives.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Primitives.hs
@@ -53,5 +53,5 @@ txhash = mustBeReplaced
 blocknum :: Int
 blocknum = mustBeReplaced
 
-error :: a
+error :: () -> a
 error = mustBeReplaced

--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -205,6 +205,7 @@ errors = testGroup "Errors" [
     golden "integer" integer
     , golden "free" free
     , golden "list" list
+    , golden "valueRestriction" valueRestriction
   ]
 
 integer :: PlcCode
@@ -215,3 +216,8 @@ free = plc (True && False)
 
 list :: PlcCode
 list = plc ([(1::Int)])
+
+-- It's little tricky to get something that GHC actually turns into a polymorphic computation! We use our value twice
+-- at different types to prevent the obvious specialization.
+valueRestriction :: PlcCode
+valueRestriction = plc (let { f :: forall a . a; f = Prims.error (); } in (f @Bool, f @Int))

--- a/core-to-plc/test/error.plc.golden
+++ b/core-to-plc/test/error.plc.golden
@@ -1,3 +1,6 @@
 (program 1.0.0
-  { (abs e_0 (type) (error e_0)) [(con integer) (con 64)] }
+  {
+    (abs e_0 (type) (lam thunk_1 (all a_2 (type) (fun a_2 a_2)) (error e_0)))
+    [(con integer) (con 64)]
+  }
 )

--- a/core-to-plc/test/valueRestriction.plc.golden
+++ b/core-to-plc/test/valueRestriction.plc.golden
@@ -1,0 +1,7 @@
+Error: Violation of the value restriction: Type abstraction body is not a value
+Context: Converting expr: \ (@ a) -> error @ a ()
+Context: Converting expr: let {
+                            f :: forall a. a
+                            [LclId]
+                            f = \ (@ a) -> error @ a () } in
+                          (f @ Bool, f @ Int)

--- a/core-to-plc/test/void.plc.golden
+++ b/core-to-plc/test/void.plc.golden
@@ -23,70 +23,90 @@
                       (all Bool_matchOut_8 (type) (fun Bool_matchOut_8 (fun Bool_matchOut_8 Bool_matchOut_8)))
                       [
                         (lam
-                          fail_17
-                          (fun (all any_15 (type) any_15) (all Bool_matchOut_16 (type) (fun Bool_matchOut_16 (fun Bool_matchOut_16 Bool_matchOut_16))))
+                          fail_19
+                          (fun (all a_16 (type) (fun (all a_17 (type) (fun a_17 a_17)) a_16)) (all Bool_matchOut_18 (type) (fun Bool_matchOut_18 (fun Bool_matchOut_18 Bool_matchOut_18))))
                           [
                             [
                               [
                                 {
                                   x_7
-                                  (fun (all a_19 (type) (fun a_19 a_19)) (all Bool_matchOut_18 (type) (fun Bool_matchOut_18 (fun Bool_matchOut_18 Bool_matchOut_18))))
+                                  (fun (all a_21 (type) (fun a_21 a_21)) (all Bool_matchOut_20 (type) (fun Bool_matchOut_20 (fun Bool_matchOut_20 Bool_matchOut_20))))
                                 }
                                 (lam
-                                  thunk_21
-                                  (all a_22 (type) (fun a_22 a_22))
-                                  [ fail_17 (abs e_20 (type) (error e_20)) ]
+                                  thunk_25
+                                  (all a_26 (type) (fun a_26 a_26))
+                                  [
+                                    fail_19
+                                    (abs
+                                      e_22
+                                      (type)
+                                      (lam
+                                        thunk_23
+                                        (all a_24 (type) (fun a_24 a_24))
+                                        (error e_22)
+                                      )
+                                    )
+                                  ]
                                 )
                               ]
                               (lam
-                                thunk_35
-                                (all a_36 (type) (fun a_36 a_36))
+                                thunk_41
+                                (all a_42 (type) (fun a_42 a_42))
                                 [
                                   [
                                     [
                                       {
                                         y_9
-                                        (fun (all a_24 (type) (fun a_24 a_24)) (all Bool_matchOut_23 (type) (fun Bool_matchOut_23 (fun Bool_matchOut_23 Bool_matchOut_23))))
+                                        (fun (all a_28 (type) (fun a_28 a_28)) (all Bool_matchOut_27 (type) (fun Bool_matchOut_27 (fun Bool_matchOut_27 Bool_matchOut_27))))
                                       }
                                       (lam
-                                        thunk_26
-                                        (all a_27 (type) (fun a_27 a_27))
+                                        thunk_32
+                                        (all a_33 (type) (fun a_33 a_33))
                                         [
-                                          fail_17 (abs e_25 (type) (error e_25))
+                                          fail_19
+                                          (abs
+                                            e_29
+                                            (type)
+                                            (lam
+                                              thunk_30
+                                              (all a_31 (type) (fun a_31 a_31))
+                                              (error e_29)
+                                            )
+                                          )
                                         ]
                                       )
                                     ]
                                     (lam
-                                      thunk_31
-                                      (all a_32 (type) (fun a_32 a_32))
+                                      thunk_37
+                                      (all a_38 (type) (fun a_38 a_38))
                                       (abs
-                                        Bool_matchOut_28
+                                        Bool_matchOut_34
                                         (type)
                                         (lam
-                                          False_29
-                                          Bool_matchOut_28
-                                          (lam True_30 Bool_matchOut_28 True_30)
+                                          False_35
+                                          Bool_matchOut_34
+                                          (lam True_36 Bool_matchOut_34 True_36)
                                         )
                                       )
                                     )
                                   ]
-                                  (abs a_33 (type) (lam x_34 a_33 x_34))
+                                  (abs a_39 (type) (lam x_40 a_39 x_40))
                                 ]
                               )
                             ]
-                            (abs a_37 (type) (lam x_38 a_37 x_38))
+                            (abs a_43 (type) (lam x_44 a_43 x_44))
                           ]
                         )
                         (lam
-                          ds_11
-                          (all any_10 (type) any_10)
+                          ds_12
+                          (all a_10 (type) (fun (all a_11 (type) (fun a_11 a_11)) a_10))
                           (abs
-                            Bool_matchOut_12
+                            Bool_matchOut_13
                             (type)
                             (lam
-                              False_13
-                              Bool_matchOut_12
-                              (lam True_14 Bool_matchOut_12 False_13)
+                              False_14
+                              Bool_matchOut_13
+                              (lam True_15 Bool_matchOut_13 False_14)
                             )
                           )
                         )

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -59,6 +59,8 @@ module Language.PlutusCore
     , checkTerm
     , NormalizationError
     , checkFile
+    , isTypeValue
+    , isTermValue
     -- * Type synthesis
     , typecheckProgram
     , typecheckTerm

--- a/language-plutus-core/src/Language/PlutusCore/Normalize.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Normalize.hs
@@ -9,6 +9,7 @@ module Language.PlutusCore.Normalize ( check
                                      , checkTerm
                                      , NormalizationError
                                      , isTypeValue
+                                     , isTermValue
                                      ) where
 
 import           Control.Monad.Except
@@ -49,6 +50,9 @@ checkT (Apply l t t')    = Apply l <$> checkT t <*> checkT t'
 checkT (TyAbs l tn k t)  = TyAbs l tn k <$> termValue t
 checkT t@Var{}           = pure t
 checkT t@Constant{}      = pure t
+
+isTermValue :: Term tyname name a -> Bool
+isTermValue = isRight . termValue
 
 -- ensure a term is a value
 termValue :: Term tyname name a -> Either (NormalizationError tyname name a) (Term tyname name a)

--- a/plutus-use-cases/shell.nix
+++ b/plutus-use-cases/shell.nix
@@ -1,0 +1,1 @@
+(import ../. {}).plutus-use-cases.env

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
@@ -81,16 +81,16 @@ contributionScript _ _  = PlutusTx inner where
             -- | Check that a transaction input is signed by the private key of the given
             --   public key.
             signedBy :: TxIn -> PubKey -> Bool
-            signedBy = Prim.error
+            signedBy = Prim.error ()
 
             infixr 3 &&
             (&&) :: Bool -> Bool -> Bool
-            (&&) = Prim.error
+            (&&) = Prim.error ()
 
             -- | Check that a pending transaction is signed by the private key
             --   of the given public key.
             signedByT :: PendingTx -> PubKey -> Bool
-            signedByT = Prim.error
+            signedByT = Prim.error ()
 
             PendingTx pendingTxBlockHeight _ pendingTxTransaction = p
 
@@ -119,7 +119,7 @@ contributionScript _ _  = PlutusTx inner where
                         -- were committed by this contributor
                     in refundable
         in
-        if isValid then () else Prim.error) ||])
+        if isValid then () else Prim.error ()) ||])
 
 -- | Given the campaign data and the output from the contributing transaction,
 --   make a trigger that fires when the transaction can be refunded.

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Swap.hs
@@ -46,7 +46,7 @@ swapValidator _ = PlutusTx result where
         let
             infixr 3 &&
             (&&) :: Bool -> Bool -> Bool
-            (&&) = Prim.error
+            (&&) = Prim.error ()
 
             mn :: Int -> Int -> Int
             mn a b = if a < b then a else b
@@ -55,24 +55,24 @@ swapValidator _ = PlutusTx result where
             mx a b = if a > b then a else b
 
             extractVerifyAt :: OracleValue (Ratio Int) -> PubKey -> Int -> BlockHeight -> Ratio Int
-            extractVerifyAt = Prim.error
+            extractVerifyAt = Prim.error ()
 
             round :: Ratio Int -> Int
-            round = Prim.error
+            round = Prim.error ()
 
             -- | Convert an [[Int]] to a [[Ratio Int]]
             fromInt :: Int -> Ratio Int
-            fromInt = Prim.error
+            fromInt = Prim.error ()
 
             signedBy :: TxIn -> PubKey -> Bool
-            signedBy = Prim.error
+            signedBy = Prim.error ()
 
             infixr 3 ||
             (||) :: Bool -> Bool -> Bool
-            (||) = Prim.error
+            (||) = Prim.error ()
 
             isPubKeyOutput :: TxOut a -> PubKey -> Bool
-            isPubKeyOutput = Prim.error
+            isPubKeyOutput = Prim.error ()
 
             -- Verify the authenticity of the oracle value and compute
             -- the payments.
@@ -144,7 +144,7 @@ swapValidator _ = PlutusTx result where
 
 
         in
-        if inConditions && outConditions then () else Prim.error
+        if inConditions && outConditions then () else Prim.error ()
         )
 
 {- Note [Swap Transactions]


### PR DESCRIPTION
As discussed on the call, we're keeping the value restriction, at least for now.

There are two ways we can deal with this:
1. Mangle all our `TyForall`s, `TyAbs`s, and `TyInst`s to delay and force all over the place.
2. Pass on the value restriction to users as an error.

I've opted to go for 2. at the moment, after discussion with @mchakravarty. See the note in the source for more details, and a few wrinkles we need to deal with. As evidence that this will not be a problem for users, I had to actually try quite hard to get an example where we hit the error.

The only user-facing change is that the primitive `error` we export now has type `forall a . () -> a` instead of `forall a. a` (we in fact can make no terms of that type!).