### PR TITLE
core-to-plc: correctly convert spec booleans into our booleans

### DIFF
--- a/core-to-plc/core-to-plc.cabal
+++ b/core-to-plc/core-to-plc.cabal
@@ -24,6 +24,8 @@ library
         Language.Plutus.CoreToPLC.Primitives
     other-modules:
         Language.Plutus.CoreToPLC
+        Language.Plutus.CoreToPLC.Builtins
+        Language.Plutus.CoreToPLC.Laziness
     hs-source-dirs: src
     default-language: Haskell2010
     default-extensions: ExplicitForAll ScopedTypeVariables

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Builtins.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Builtins.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Functions for working with PLC builtins.
+module Language.Plutus.CoreToPLC.Builtins where
+
+import           Language.Plutus.CoreToPLC.Laziness
+
+import           GHC.Natural
+import qualified Language.PlutusCore                as PLC
+import           Language.PlutusCore.Quote
+
+{- Note [Spec booleans and Scott booleans]
+Annoyingly, the spec version of booleans bakes in the laziness of the branches,
+i.e. has type
+forall a . (() -> a) -> (() -> a) -> a
+Our booleans converted from Haskell's Bool have type
+forall a . a -> a -> a
+because we insert the laziness when we do case expressions.
+
+So we need to be able to turn the spec's booleans into our booleans.
+-}
+
+-- See Note [Spec booleans and Scott booleans]
+specBoolToScottBool :: MonadQuote m => PLC.Term PLC.TyName PLC.Name () -> m (PLC.Term PLC.TyName PLC.Name ())
+specBoolToScottBool b = do
+    n <- liftQuote $ freshTyName () "Bool_match_out"
+    let outTy = PLC.TyVar () n
+    let instantiated = PLC.TyInst () b outTy
+    a1 <- liftQuote $ freshName () "arg1"
+    a2 <- liftQuote $ freshName () "arg2"
+    arg1 <- delay $ PLC.Var () a1
+    arg2 <- delay $ PLC.Var () a1
+    pure $ PLC.TyAbs () n (PLC.Type ()) $ PLC.LamAbs () a1 outTy $ PLC.LamAbs () a2 outTy $ PLC.Apply () (PLC.Apply () instantiated arg1) arg2
+
+binarySpecBoolFunToScottBoolFun :: MonadQuote m => PLC.Type PLC.TyName () -> PLC.Term PLC.TyName PLC.Name () -> m (PLC.Term PLC.TyName PLC.Name ())
+binarySpecBoolFunToScottBoolFun ty f = do
+    n1 <- liftQuote $ freshName () "arg1"
+    n2 <- liftQuote $ freshName () "arg2"
+    inner <- specBoolToScottBool $ PLC.Apply () (PLC.Apply () f (PLC.Var () n1)) (PLC.Var () n2)
+    pure $ PLC.LamAbs () n1 ty $ PLC.LamAbs () n2 ty inner
+
+haskellIntSize :: Natural
+haskellIntSize = 64
+
+haskellBSSize :: Natural
+haskellBSSize = 64
+
+instSize :: Natural -> PLC.Term tyname name () -> PLC.Term tyname name ()
+instSize n t = PLC.TyInst () t (PLC.TyInt () n)
+
+appSize :: Natural -> PLC.Type tyname () -> PLC.Type tyname ()
+appSize n t = PLC.TyApp () t (PLC.TyInt () n)
+
+mkConstant :: PLC.BuiltinName -> PLC.Term tyname name ()
+mkConstant n = PLC.Constant () $ PLC.BuiltinName () n
+
+mkIntFun :: MonadQuote m => PLC.BuiltinName -> m (PLC.Term PLC.TyName PLC.Name ())
+mkIntFun name = pure $ instSize haskellIntSize (mkConstant name)
+
+mkIntRel :: MonadQuote m => PLC.BuiltinName -> m (PLC.Term PLC.TyName PLC.Name ())
+mkIntRel name = do
+    let intTy = appSize haskellIntSize (PLC.TyBuiltin () PLC.TyInteger)
+    binarySpecBoolFunToScottBoolFun intTy $ instSize haskellIntSize (mkConstant name)
+
+mkBsRel :: MonadQuote m => PLC.BuiltinName -> m (PLC.Term PLC.TyName PLC.Name ())
+mkBsRel name = do
+    let bsTy = appSize haskellBSSize (PLC.TyBuiltin () PLC.TyByteString)
+    binarySpecBoolFunToScottBoolFun bsTy $ instSize haskellBSSize (mkConstant name)

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Laziness.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Laziness.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Simulating laziness.
+module Language.Plutus.CoreToPLC.Laziness where
+
+import qualified Language.PlutusCore                  as PLC
+import           Language.PlutusCore.Quote
+import qualified Language.PlutusCore.StdLib.Data.Unit as Unit
+
+{- Note [Object- vs meta-language combinators]
+Many of the things we define as *meta*-langugage combinators (i.e. operations on terms) could be defined
+as combinators in the object language (i.e. terms). For example, we can define 'delay' as taking a term
+and returning a lambda that takes unit and returns the term, or we could define a 'delay' term
+
+\t : a . \u : unit . t
+
+We generally prefer the metalanguage approach despite the fact that we could share combinators
+with the standard library because it makes the generated terms simpler without the need for
+a simplifier pass. Also, PLC isn't lazy, so combinators work less well.
+-}
+
+delay :: MonadQuote m => PLC.Term PLC.TyName PLC.Name () -> m (PLC.Term PLC.TyName PLC.Name ())
+delay body = PLC.LamAbs () <$> liftQuote (freshName () "thunk") <*> liftQuote Unit.getBuiltinUnit <*> pure body
+
+delayType :: MonadQuote m => PLC.Type PLC.TyName () -> m (PLC.Type PLC.TyName ())
+delayType orig = PLC.TyFun () <$> liftQuote Unit.getBuiltinUnit <*> pure orig
+
+force :: MonadQuote m => PLC.Term PLC.TyName PLC.Name () -> m (PLC.Term PLC.TyName PLC.Name ())
+force thunk = PLC.Apply () thunk <$> liftQuote Unit.getBuiltinUnitval

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Primitives.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Primitives.hs
@@ -3,26 +3,8 @@ module Language.Plutus.CoreToPLC.Primitives where
 
 import           Language.Plutus.CoreToPLC.Error
 
-import           GHC.Natural
-import qualified Language.PlutusCore             as PLC
-
 -- | An abstract data type representing bytestrings in Plutus Core.
 data ByteString
-
-haskellIntSize :: Natural
-haskellIntSize = 64
-
-haskellBSSize :: Natural
-haskellBSSize = 64
-
-instSize :: Natural -> PLC.Term tyname name () -> PLC.Term tyname name ()
-instSize n t = PLC.TyInst () t (PLC.TyInt () n)
-
-appSize :: Natural -> PLC.Type tyname () -> PLC.Type tyname ()
-appSize n t = PLC.TyApp () t (PLC.TyInt () n)
-
-mkConstant :: PLC.BuiltinName -> PLC.Term tyname name ()
-mkConstant n = PLC.Constant () $ PLC.BuiltinName () n
 
 -- TODO: resizing primitives? better handling of sizes?
 

--- a/core-to-plc/test/IllTyped.hs
+++ b/core-to-plc/test/IllTyped.hs
@@ -21,7 +21,3 @@ verify = plc (\(x::Prims.ByteString) (y::Prims.ByteString) (z::Prims.ByteString)
 
 tupleMatch :: PlcCode
 tupleMatch = plc (\(x:: (Int, Int)) -> let (a, b) = x in a)
-
--- Has a Void in it
-void :: PlcCode
-void = plc (\(x::Int) (y::Int) -> let a x' y' = case (x', y') of { (True, True) -> True; _ -> False; } in (x == y) `a` (y == x))

--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -67,6 +67,7 @@ primitives = testGroup "Primitive types and operations" [
   , golden "void" void
   , golden "intPlus" intPlus
   , golden "error" errorPlc
+  , golden "ifThenElse" ifThenElse
   , golden "blocknum" blocknumPlc
   , golden "bytestring" bytestring
   , golden "verify" verify
@@ -90,11 +91,18 @@ intCompare = plc (\(x::Int) (y::Int) -> x < y)
 intEq :: PlcCode
 intEq = plc (\(x::Int) (y::Int) -> x == y)
 
+-- Has a Void in it
+void :: PlcCode
+void = plc (\(x::Int) (y::Int) -> let a x' y' = case (x', y') of { (True, True) -> True; _ -> False; } in (x == y) `a` (y == x))
+
 intPlus :: PlcCode
 intPlus = plc (\(x::Int) (y::Int) -> x + y)
 
 errorPlc :: PlcCode
 errorPlc = plc (Prims.error @Int)
+
+ifThenElse :: PlcCode
+ifThenElse = plc (\(x::Int) (y::Int) -> if x == y then x else y)
 
 structure :: TestTree
 structure = testGroup "Structures" [

--- a/core-to-plc/test/ifThenElse.plc.golden
+++ b/core-to-plc/test/ifThenElse.plc.golden
@@ -1,0 +1,65 @@
+(program 1.0.0
+  (lam
+    ds_0
+    [(con integer) (con 64)]
+    (lam
+      ds_1
+      [(con integer) (con 64)]
+      [
+        [
+          [
+            {
+              [
+                [
+                  (lam
+                    arg1_2
+                    [(con integer) (con 64)]
+                    (lam
+                      arg2_3
+                      [(con integer) (con 64)]
+                      (abs
+                        Bool_match_out_4
+                        (type)
+                        (lam
+                          arg1_5
+                          Bool_match_out_4
+                          (lam
+                            arg2_6
+                            Bool_match_out_4
+                            [
+                              [
+                                {
+                                  [
+                                    [ { (con equalsInteger) (con 64) } arg1_2 ]
+                                    arg2_3
+                                  ]
+                                  Bool_match_out_4
+                                }
+                                (lam
+                                  thunk_7 (all a_8 (type) (fun a_8 a_8)) arg1_5
+                                )
+                              ]
+                              (lam
+                                thunk_9 (all a_10 (type) (fun a_10 a_10)) arg1_5
+                              )
+                            ]
+                          )
+                        )
+                      )
+                    )
+                  )
+                  ds_0
+                ]
+                ds_1
+              ]
+              (fun (all a_11 (type) (fun a_11 a_11)) [(con integer) (con 64)])
+            }
+            (lam thunk_12 (all a_13 (type) (fun a_13 a_13)) ds_1)
+          ]
+          (lam thunk_14 (all a_15 (type) (fun a_15 a_15)) ds_0)
+        ]
+        (abs a_16 (type) (lam x_17 a_16 x_17))
+      ]
+    )
+  )
+)

--- a/core-to-plc/test/intCompare.plc.golden
+++ b/core-to-plc/test/intCompare.plc.golden
@@ -5,7 +5,44 @@
     (lam
       ds_1
       [(con integer) (con 64)]
-      [ [ { (con lessThanInteger) (con 64) } ds_0 ] ds_1 ]
+      [
+        [
+          (lam
+            arg1_2
+            [(con integer) (con 64)]
+            (lam
+              arg2_3
+              [(con integer) (con 64)]
+              (abs
+                Bool_match_out_4
+                (type)
+                (lam
+                  arg1_5
+                  Bool_match_out_4
+                  (lam
+                    arg2_6
+                    Bool_match_out_4
+                    [
+                      [
+                        {
+                          [
+                            [ { (con lessThanInteger) (con 64) } arg1_2 ] arg2_3
+                          ]
+                          Bool_match_out_4
+                        }
+                        (lam thunk_7 (all a_8 (type) (fun a_8 a_8)) arg1_5)
+                      ]
+                      (lam thunk_9 (all a_10 (type) (fun a_10 a_10)) arg1_5)
+                    ]
+                  )
+                )
+              )
+            )
+          )
+          ds_0
+        ]
+        ds_1
+      ]
     )
   )
 )

--- a/core-to-plc/test/intEq.plc.golden
+++ b/core-to-plc/test/intEq.plc.golden
@@ -5,7 +5,42 @@
     (lam
       ds_1
       [(con integer) (con 64)]
-      [ [ { (con equalsInteger) (con 64) } ds_0 ] ds_1 ]
+      [
+        [
+          (lam
+            arg1_2
+            [(con integer) (con 64)]
+            (lam
+              arg2_3
+              [(con integer) (con 64)]
+              (abs
+                Bool_match_out_4
+                (type)
+                (lam
+                  arg1_5
+                  Bool_match_out_4
+                  (lam
+                    arg2_6
+                    Bool_match_out_4
+                    [
+                      [
+                        {
+                          [ [ { (con equalsInteger) (con 64) } arg1_2 ] arg2_3 ]
+                          Bool_match_out_4
+                        }
+                        (lam thunk_7 (all a_8 (type) (fun a_8 a_8)) arg1_5)
+                      ]
+                      (lam thunk_9 (all a_10 (type) (fun a_10 a_10)) arg1_5)
+                    ]
+                  )
+                )
+              )
+            )
+          )
+          ds_0
+        ]
+        ds_1
+      ]
     )
   )
 )

--- a/core-to-plc/test/letFun.plc.golden
+++ b/core-to-plc/test/letFun.plc.golden
@@ -9,7 +9,46 @@
         (lam
           z_2
           [(con integer) (con 64)]
-          [ [ { (con equalsInteger) (con 64) } ds_0 ] z_2 ]
+          [
+            [
+              (lam
+                arg1_3
+                [(con integer) (con 64)]
+                (lam
+                  arg2_4
+                  [(con integer) (con 64)]
+                  (abs
+                    Bool_match_out_5
+                    (type)
+                    (lam
+                      arg1_6
+                      Bool_match_out_5
+                      (lam
+                        arg2_7
+                        Bool_match_out_5
+                        [
+                          [
+                            {
+                              [
+                                [ { (con equalsInteger) (con 64) } arg1_3 ]
+                                arg2_4
+                              ]
+                              Bool_match_out_5
+                            }
+                            (lam thunk_8 (all a_9 (type) (fun a_9 a_9)) arg1_6)
+                          ]
+                          (lam thunk_10 (all a_11 (type) (fun a_11 a_11)) arg1_6
+                          )
+                        ]
+                      )
+                    )
+                  )
+                )
+              )
+              ds_0
+            ]
+            z_2
+          ]
         )
         ds_1
       ]

--- a/core-to-plc/test/void.plc.golden
+++ b/core-to-plc/test/void.plc.golden
@@ -7,121 +7,202 @@
       [(con integer) (con 64)]
       [
         (lam
-          eta_3
-          (all Bool_matchOut_2 (type) (fun Bool_matchOut_2 (fun Bool_matchOut_2 Bool_matchOut_2)))
+          eta_12
+          (all Bool_matchOut_11 (type) (fun Bool_matchOut_11 (fun Bool_matchOut_11 Bool_matchOut_11)))
           [
             (lam
-              eta_5
-              (all Bool_matchOut_4 (type) (fun Bool_matchOut_4 (fun Bool_matchOut_4 Bool_matchOut_4)))
+              eta_23
+              (all Bool_matchOut_22 (type) (fun Bool_matchOut_22 (fun Bool_matchOut_22 Bool_matchOut_22)))
               [
                 [
                   (lam
-                    x_7
-                    (all Bool_matchOut_6 (type) (fun Bool_matchOut_6 (fun Bool_matchOut_6 Bool_matchOut_6)))
+                    x_25
+                    (all Bool_matchOut_24 (type) (fun Bool_matchOut_24 (fun Bool_matchOut_24 Bool_matchOut_24)))
                     (lam
-                      y_9
-                      (all Bool_matchOut_8 (type) (fun Bool_matchOut_8 (fun Bool_matchOut_8 Bool_matchOut_8)))
+                      y_27
+                      (all Bool_matchOut_26 (type) (fun Bool_matchOut_26 (fun Bool_matchOut_26 Bool_matchOut_26)))
                       [
                         (lam
-                          fail_19
-                          (fun (all a_16 (type) (fun (all a_17 (type) (fun a_17 a_17)) a_16)) (all Bool_matchOut_18 (type) (fun Bool_matchOut_18 (fun Bool_matchOut_18 Bool_matchOut_18))))
+                          fail_37
+                          (fun (all a_34 (type) (fun (all a_35 (type) (fun a_35 a_35)) a_34)) (all Bool_matchOut_36 (type) (fun Bool_matchOut_36 (fun Bool_matchOut_36 Bool_matchOut_36))))
                           [
                             [
                               [
                                 {
-                                  x_7
-                                  (fun (all a_21 (type) (fun a_21 a_21)) (all Bool_matchOut_20 (type) (fun Bool_matchOut_20 (fun Bool_matchOut_20 Bool_matchOut_20))))
+                                  x_25
+                                  (fun (all a_39 (type) (fun a_39 a_39)) (all Bool_matchOut_38 (type) (fun Bool_matchOut_38 (fun Bool_matchOut_38 Bool_matchOut_38))))
                                 }
                                 (lam
-                                  thunk_25
-                                  (all a_26 (type) (fun a_26 a_26))
+                                  thunk_43
+                                  (all a_44 (type) (fun a_44 a_44))
                                   [
-                                    fail_19
+                                    fail_37
                                     (abs
-                                      e_22
+                                      e_40
                                       (type)
                                       (lam
-                                        thunk_23
-                                        (all a_24 (type) (fun a_24 a_24))
-                                        (error e_22)
+                                        thunk_41
+                                        (all a_42 (type) (fun a_42 a_42))
+                                        (error e_40)
                                       )
                                     )
                                   ]
                                 )
                               ]
                               (lam
-                                thunk_41
-                                (all a_42 (type) (fun a_42 a_42))
+                                thunk_59
+                                (all a_60 (type) (fun a_60 a_60))
                                 [
                                   [
                                     [
                                       {
-                                        y_9
-                                        (fun (all a_28 (type) (fun a_28 a_28)) (all Bool_matchOut_27 (type) (fun Bool_matchOut_27 (fun Bool_matchOut_27 Bool_matchOut_27))))
+                                        y_27
+                                        (fun (all a_46 (type) (fun a_46 a_46)) (all Bool_matchOut_45 (type) (fun Bool_matchOut_45 (fun Bool_matchOut_45 Bool_matchOut_45))))
                                       }
                                       (lam
-                                        thunk_32
-                                        (all a_33 (type) (fun a_33 a_33))
+                                        thunk_50
+                                        (all a_51 (type) (fun a_51 a_51))
                                         [
-                                          fail_19
+                                          fail_37
                                           (abs
-                                            e_29
+                                            e_47
                                             (type)
                                             (lam
-                                              thunk_30
-                                              (all a_31 (type) (fun a_31 a_31))
-                                              (error e_29)
+                                              thunk_48
+                                              (all a_49 (type) (fun a_49 a_49))
+                                              (error e_47)
                                             )
                                           )
                                         ]
                                       )
                                     ]
                                     (lam
-                                      thunk_37
-                                      (all a_38 (type) (fun a_38 a_38))
+                                      thunk_55
+                                      (all a_56 (type) (fun a_56 a_56))
                                       (abs
-                                        Bool_matchOut_34
+                                        Bool_matchOut_52
                                         (type)
                                         (lam
-                                          False_35
-                                          Bool_matchOut_34
-                                          (lam True_36 Bool_matchOut_34 True_36)
+                                          False_53
+                                          Bool_matchOut_52
+                                          (lam True_54 Bool_matchOut_52 True_54)
                                         )
                                       )
                                     )
                                   ]
-                                  (abs a_39 (type) (lam x_40 a_39 x_40))
+                                  (abs a_57 (type) (lam x_58 a_57 x_58))
                                 ]
                               )
                             ]
-                            (abs a_43 (type) (lam x_44 a_43 x_44))
+                            (abs a_61 (type) (lam x_62 a_61 x_62))
                           ]
                         )
                         (lam
-                          ds_12
-                          (all a_10 (type) (fun (all a_11 (type) (fun a_11 a_11)) a_10))
+                          ds_30
+                          (all a_28 (type) (fun (all a_29 (type) (fun a_29 a_29)) a_28))
                           (abs
-                            Bool_matchOut_13
+                            Bool_matchOut_31
                             (type)
                             (lam
-                              False_14
-                              Bool_matchOut_13
-                              (lam True_15 Bool_matchOut_13 False_14)
+                              False_32
+                              Bool_matchOut_31
+                              (lam True_33 Bool_matchOut_31 False_32)
                             )
                           )
                         )
                       ]
                     )
                   )
-                  eta_3
+                  eta_12
                 ]
-                eta_5
+                eta_23
               ]
             )
-            [ [ { (con equalsInteger) (con 64) } ds_1 ] ds_0 ]
+            [
+              [
+                (lam
+                  arg1_13
+                  [(con integer) (con 64)]
+                  (lam
+                    arg2_14
+                    [(con integer) (con 64)]
+                    (abs
+                      Bool_match_out_15
+                      (type)
+                      (lam
+                        arg1_16
+                        Bool_match_out_15
+                        (lam
+                          arg2_17
+                          Bool_match_out_15
+                          [
+                            [
+                              {
+                                [
+                                  [ { (con equalsInteger) (con 64) } arg1_13 ]
+                                  arg2_14
+                                ]
+                                Bool_match_out_15
+                              }
+                              (lam
+                                thunk_18
+                                (all a_19 (type) (fun a_19 a_19))
+                                arg1_16
+                              )
+                            ]
+                            (lam
+                              thunk_20 (all a_21 (type) (fun a_21 a_21)) arg1_16
+                            )
+                          ]
+                        )
+                      )
+                    )
+                  )
+                )
+                ds_1
+              ]
+              ds_0
+            ]
           ]
         )
-        [ [ { (con equalsInteger) (con 64) } ds_0 ] ds_1 ]
+        [
+          [
+            (lam
+              arg1_2
+              [(con integer) (con 64)]
+              (lam
+                arg2_3
+                [(con integer) (con 64)]
+                (abs
+                  Bool_match_out_4
+                  (type)
+                  (lam
+                    arg1_5
+                    Bool_match_out_4
+                    (lam
+                      arg2_6
+                      Bool_match_out_4
+                      [
+                        [
+                          {
+                            [
+                              [ { (con equalsInteger) (con 64) } arg1_2 ] arg2_3
+                            ]
+                            Bool_match_out_4
+                          }
+                          (lam thunk_7 (all a_8 (type) (fun a_8 a_8)) arg1_5)
+                        ]
+                        (lam thunk_9 (all a_10 (type) (fun a_10 a_10)) arg1_5)
+                      ]
+                    )
+                  )
+                )
+              )
+            )
+            ds_0
+          ]
+          ds_1
+        ]
       ]
     )
   )


### PR DESCRIPTION
As I recently noticed (cf my email today), the booleans in the spec are not the usual Scott-encoded booleans, because they bake in the lazy matching. Regardless of whether this is a good idea or not, this means that we need to convert the spec-booleans that come out of builtins into our booleans. This is something of a hassle, since we'd been translating to builtins as functions, so we need to post-compose the conversion function, which adds some ceremony. I ended up restructuring some of the primitive code a bit to make this less annoying.

(And I realised this should almost certainly use Roman's typed builtin work in some way, but I'm leaving that for now).

The resulting code is somewhat painful, but it will get nicer again if we bring our booleans into sync.

On top of the value restriction PR, this allows me to move another test to the typechecking section!