### PR TITLE
[CGP-307] Add transaction types to `wallet-api`

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -78287,6 +78287,7 @@ license = stdenv.lib.licenses.mit;
 , cryptonite
 , free
 , ghc
+, hedgehog
 , language-plutus-core
 , memory
 , mmorph
@@ -78295,6 +78296,8 @@ license = stdenv.lib.licenses.mit;
 , plutus-th
 , prettyprinter
 , stdenv
+, tasty
+, tasty-hedgehog
 , template-haskell
 , text
 , transformers
@@ -78321,6 +78324,21 @@ operational
 plutus-th
 prettyprinter
 template-haskell
+text
+transformers
+];
+testHaskellDepends = [
+base
+bytestring
+containers
+core-to-plc
+cryptonite
+hedgehog
+mtl
+operational
+plutus-th
+tasty
+tasty-hedgehog
 text
 transformers
 ];

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -78281,10 +78281,14 @@ license = stdenv.lib.licenses.mit;
   mkDerivation
 , base
 , bytestring
+, cborg
 , containers
+, core-to-plc
+, cryptonite
 , free
 , ghc
 , language-plutus-core
+, memory
 , mmorph
 , mtl
 , operational
@@ -78303,10 +78307,14 @@ src = ./../wallet-api;
 libraryHaskellDepends = [
 base
 bytestring
+cborg
 containers
+core-to-plc
+cryptonite
 free
 ghc
 language-plutus-core
+memory
 mmorph
 mtl
 operational

--- a/wallet-api/src/Wallet/Emulator.hs
+++ b/wallet-api/src/Wallet/Emulator.hs
@@ -1,0 +1,7 @@
+module Wallet.Emulator(
+    module Types,
+    module UTXO
+    ) where
+
+import           Wallet.Emulator.Types as Types
+import           Wallet.UTXO           as UTXO

--- a/wallet-api/src/Wallet/UTXO.hs
+++ b/wallet-api/src/Wallet/UTXO.hs
@@ -1,0 +1,373 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections   #-}
+module Wallet.UTXO(
+    -- * Basic types
+    Value(..),
+    TxId(..),
+    Address(..),
+    Height(..),
+    height,
+    -- * Script types
+    Validator(..),
+    hashValidator,
+    Redeemer(..),
+    DataScript(..),
+    -- * Transactions
+    Tx(..),
+    TxStripped(..),
+    strip,
+    preHash,
+    hashTx,
+    dataTxo,
+    TxIn(..),
+    TxOut(..),
+    TxOutRef(..),
+    -- * Blockchain & UTxO model
+    Block,
+    Blockchain,
+    BlockchainState(..),
+    state,
+    transaction,
+    out,
+    value,
+    unspentOutputsTx,
+    spentOutputs,
+    unspentOutputs,
+    validTx,
+    -- * Scripts
+    validate,
+    -- * Encodings
+    encodeValue,
+    encodeValidator,
+    encodeDataScript,
+    hashDataScript,
+    encodeRedeemer,
+    hashRedeemer,
+    encodeHeight,
+    encodeTxId,
+    encodeAddress,
+    encodeTx,
+    encodeTxOutRef,
+    encodeTxIn,
+    encodeTxOut
+    ) where
+
+import           Codec.CBOR.Encoding              (Encoding)
+import qualified Codec.CBOR.Encoding              as Enc
+import qualified Codec.CBOR.Write                 as Write
+import           Control.Monad                    (join)
+import           Crypto.Hash                      (Digest, SHA256, hash)
+import qualified Data.ByteArray                   as BA
+import qualified Data.ByteString.Char8            as BS
+import qualified Data.ByteString.Lazy             as BSL
+import           Data.Map                         (Map)
+import qualified Data.Map                         as Map
+import           Data.Maybe                       (fromMaybe, listToMaybe)
+import           Data.Semigroup                   (Semigroup (..))
+
+import           Language.Plutus.CoreToPLC.Plugin (PlcCode, getSerializedCode)
+
+{- Note [Serialisation and hashing]
+
+We use cryptonite for generating hashes, which requires us to serialise values
+to a strict ByteString (to implement `Data.ByteArray.ByteArrayAccess`).
+
+Binary serialisation could be achieved via
+
+1. The `binary` package
+2. The `cbor` package
+
+(1) is used in the cardano-sl repository, and (2) is used in the
+`language-plutus-core` project in this repository.
+
+In this module we use (2) because of the precedent. This means however that we
+may generate different hashes for the same transactions compared to cardano-sl.
+This might become a problem if/when we want to support "imports" of some real
+blockchain state into the emulator.
+
+However, it should be easy to change the serialisation mechanism later on,
+especially because we only need one direction (to binary).
+
+-}
+
+-- | Cryptocurrency value
+--
+newtype Value = Value { getValue :: Integer }
+    deriving (Eq, Ord, Show, Num)
+
+encodeValue :: Value -> Encoding
+encodeValue = Enc.encodeInteger . getValue
+
+-- | Transaction ID (double SHA256 hash of the transaction)
+newtype TxId = TxId { getTxId :: Digest SHA256 }
+    deriving (Eq, Ord, Show)
+
+encodeTxId :: TxId -> Encoding
+encodeTxId = Enc.encodeBytes . BA.convert . getTxId
+
+-- | A payment address is a double SHA256 of a
+--   UTxO output's validator script (and presumably its data script).
+--   This corresponds to a Bitcoing pay-to-witness-script-hash
+newtype Address = Address { getAddress :: Digest SHA256 }
+    deriving (Eq, Ord, Show)
+
+encodeAddress :: Address -> Encoding
+encodeAddress = Enc.encodeBytes . BA.convert . getAddress
+
+-- | A validator is a PLC script.
+newtype Validator = Validator { getValidator :: PlcCode }
+
+instance Show Validator where
+    show = const "Validator { <script> }"
+
+instance Eq Validator where
+    (Validator l) == (Validator r) = -- TODO: Deriving via
+        getSerializedCode l == getSerializedCode r
+
+instance Ord Validator where
+    compare (Validator l) (Validator r) = -- TODO: Deriving via
+        getSerializedCode l `compare` getSerializedCode r
+
+encPlc :: PlcCode -> Encoding
+encPlc = Enc.encodeBytes . BSL.toStrict  . getSerializedCode
+
+encodeValidator :: Validator -> Encoding
+encodeValidator = encPlc . getValidator
+
+-- | Hash a validator script to get an address
+hashValidator :: Validator -> Address
+hashValidator = Address . hash . Write.toStrictByteString . encodeValidator
+
+-- | Data script (supplied by producer of the transaction output)
+newtype DataScript = DataScript { getDataScript :: PlcCode  }
+
+instance Show DataScript where
+    show = const "DataScript { <script> }"
+
+instance Eq DataScript where
+    (DataScript l) == (DataScript r) = -- TODO: Deriving via
+        getSerializedCode l == getSerializedCode r
+
+instance Ord DataScript where
+    compare (DataScript l) (DataScript r) = -- TODO: Deriving via
+        getSerializedCode l `compare` getSerializedCode r
+
+encodeDataScript :: DataScript -> Encoding
+encodeDataScript = encPlc . getDataScript
+
+-- | Hash a data script to get an address
+hashDataScript :: DataScript -> Address
+hashDataScript = Address . hash . Write.toStrictByteString . encodeDataScript
+
+-- | Redeemer (supplied by consumer of the transaction output)
+newtype Redeemer = Redeemer { getRedeemer :: PlcCode }
+
+instance Show Redeemer where
+    show = const "Redeemer { <script> }"
+
+instance Eq Redeemer where
+    (Redeemer l) == (Redeemer r) = -- TODO: Deriving via
+        getSerializedCode l == getSerializedCode r
+
+instance Ord Redeemer where
+    compare (Redeemer l) (Redeemer r) = -- TODO: Deriving via
+        getSerializedCode l `compare` getSerializedCode r
+
+encodeRedeemer :: Redeemer -> Encoding
+encodeRedeemer = encPlc . getRedeemer
+
+-- | Hash a redeemer script to get an address
+hashRedeemer :: Redeemer -> Address
+hashRedeemer = Address . hash . Write.toStrictByteString . encodeRedeemer
+
+-- | Block height
+newtype Height = Height { getHeight :: Integer }
+    deriving (Eq, Ord, Show)
+
+encodeHeight :: Height -> Encoding
+encodeHeight = Enc.encodeInteger . getHeight
+
+-- | The height of a blockchain
+height :: Blockchain -> Height
+height = Height . fromIntegral . length . join
+
+-- | Transaction including witnesses for its inputs
+data Tx = Tx {
+    txInputs  :: [TxIn],
+    txOutputs :: [TxOut],
+    txForge   :: !Value,
+    txFee     :: !Value
+    } deriving (Show, Eq, Ord)
+
+encodeTx :: Tx -> Encoding
+encodeTx Tx{..} =
+    foldMap encodeTxIn txInputs
+    <> foldMap encodeTxOut txOutputs
+    <> encodeValue txForge
+    <> encodeValue txFee
+
+instance BA.ByteArrayAccess Tx where
+    length        = BA.length . Write.toStrictByteString . encodeTx
+    withByteArray = BA.withByteArray . Write.toStrictByteString . encodeTx
+
+-- | Check that all values in a transaction are no.
+--
+validValuesTx :: Tx -> Bool
+validValuesTx Tx{..}
+  = all ((>= 0) . txOutValue) txOutputs && txForge >= 0 && txFee >= 0
+
+-- | Transaction without witnesses for its inputs
+data TxStripped = TxStripped {
+    txStrippedInputs  :: [TxOutRef],
+    txStrippedOutputs :: [TxOut],
+    txStrippedForge   :: !Value,
+    txStrippedFee     :: !Value
+    } deriving (Show, Eq, Ord)
+
+instance BA.ByteArrayAccess TxStripped where
+    length = BA.length . BS.pack . show
+    withByteArray = BA.withByteArray . BS.pack . show
+
+strip :: Tx -> TxStripped
+strip Tx{..} = TxStripped i txOutputs txForge txFee where
+    i = txInRef <$> txInputs
+
+-- | Hash a stripped transaction once
+preHash :: TxStripped -> Digest SHA256
+preHash = hash
+
+-- | Double hash of a transaction, excluding its witnesses
+hashTx :: Tx -> TxId
+hashTx = TxId . hash . preHash . strip
+
+-- | Reference to a transaction output
+data TxOutRef = TxOutRef {
+    txOutRefId  :: !TxId,
+    txOutRefIdx :: !Int -- ^ Index into the referenced transaction's outputs
+    } deriving (Show, Eq, Ord)
+
+encodeTxOutRef :: TxOutRef -> Encoding
+encodeTxOutRef TxOutRef{..} =
+    encodeTxId txOutRefId
+    <> Enc.encodeInt txOutRefIdx
+
+-- | Transaction input
+data TxIn = TxIn {
+    txInRef       :: !TxOutRef,
+    txInValidator :: !Validator,
+    txInRedeemer  :: !Redeemer
+    } deriving (Show, Eq, Ord)
+
+encodeTxIn :: TxIn -> Encoding
+encodeTxIn TxIn{..} =
+    encodeTxOutRef txInRef
+    <> encodeValidator txInValidator
+    <> encodeRedeemer txInRedeemer
+
+instance BA.ByteArrayAccess TxIn where
+    length        = BA.length . Write.toStrictByteString . encodeTxIn
+    withByteArray = BA.withByteArray . Write.toStrictByteString . encodeTxIn
+
+-- Transaction output
+data TxOut = TxOut {
+    txOutAddress :: !Address,
+    txOutValue   :: !Value,
+    txOutData    :: !DataScript
+    } deriving (Show, Eq, Ord)
+
+encodeTxOut :: TxOut -> Encoding
+encodeTxOut TxOut{..} =
+    encodeAddress txOutAddress
+    <> encodeValue txOutValue
+    <> encodeDataScript txOutData
+
+instance BA.ByteArrayAccess TxOut where
+    length        = BA.length . Write.toStrictByteString . encodeTxOut
+    withByteArray = BA.withByteArray . Write.toStrictByteString . encodeTxOut
+
+type Block = [Tx]
+type Blockchain = [Block]
+
+-- | Lookup a transaction by its hash
+transaction :: Blockchain -> TxOutRef -> Maybe Tx
+transaction bc o = listToMaybe $ filter p  $ join bc where
+    p = (txOutRefId o ==) . hashTx
+
+-- | Determine the unspent output that an input refers to
+out :: Blockchain -> TxOutRef -> Maybe TxOut
+out bc o = do
+    t <- transaction bc o
+    let i = txOutRefIdx o
+    if length (txOutputs t) <= i
+        then Nothing
+        else Just $ txOutputs t !! i
+
+-- | Determine the unspent value that an input refers to
+value :: Blockchain -> TxOutRef -> Maybe Value
+value bc o = txOutValue <$> out bc o
+
+-- | Determine the data script that an input refers to
+dataTxo :: Blockchain -> TxOutRef -> Maybe DataScript
+dataTxo bc o = txOutData <$> out bc o
+
+-- | The unspent outputs of a transaction
+unspentOutputsTx :: Tx -> Map TxOutRef TxOut
+unspentOutputsTx t = Map.fromList $ fmap f $ zip [0..] $ txOutputs t where
+    f (idx, o) = (TxOutRef (hashTx t) idx, o)
+
+-- | The outputs consumed by a transaction
+spentOutputs :: Tx -> [TxOutRef]
+spentOutputs = fmap txInRef . txInputs
+
+-- | Unspent outputs of a ledger.
+unspentOutputs :: Blockchain -> Map TxOutRef TxOut
+unspentOutputs = foldr ins Map.empty . join where
+    ins t unspent = (unspent `Map.difference` lift (spentOutputs t)) `Map.union` unspentOutputsTx t
+    lift = Map.fromList . fmap (,())
+
+-- | Ledger and transaction state available to both the validator and redeemer
+--   scripts
+--
+data BlockchainState = BlockchainState {
+    blockchainStateHeight :: Height,
+    blockchainStateTxHash :: TxId
+    }
+
+-- | Get blockchain state for a transaction
+state :: Tx -> Blockchain -> BlockchainState
+state tx bc = BlockchainState (height bc) (hashTx tx)
+
+-- | Determine whether a transaction is valid in a given ledger
+--
+-- * The inputs refer to unspent outputs, which they unlock (input validity).
+--
+-- * The transaction preserves value (value preservation).
+--
+-- * All values in the transaction are non-negative.
+--
+validTx :: Tx -> Blockchain -> Bool
+validTx t bc = inputsAreValid && valueIsPreserved && validValuesTx t where
+    inputsAreValid = all (`validatesIn` unspentOutputs bc) (txInputs t)
+    valueIsPreserved = inVal == outVal
+    inVal =
+        txForge t + sum (map (fromMaybe 0 . value bc . txInRef) (txInputs t))
+    outVal =
+        txFee t + sum (map txOutValue (txOutputs t))
+    txIn `validatesIn` allOutputs =
+        maybe False (validate (state t bc) txIn)
+        $ txInRef txIn `Map.lookup` allOutputs
+
+-- | Check whether a transaction output can be spent by the given
+--   transaction input. This involves
+--
+--   * Verifying the hash of the validator script
+--   * Evaluating the validator script with the redeemer and data script
+--
+validate :: BlockchainState -> TxIn -> TxOut -> Bool
+validate bs (TxIn _ v r) (TxOut h _ d)
+    | h /= hashValidator v = False
+    | otherwise            = runScript bs v r d
+
+-- | Evaluate a validator script with the given inputs
+runScript :: BlockchainState -> Validator -> Redeemer -> DataScript -> Bool
+runScript _ _ _ _ = True -- TODO: PLC Evaluation

--- a/wallet-api/test/Generators.hs
+++ b/wallet-api/test/Generators.hs
@@ -1,0 +1,84 @@
+module Generators(
+    -- * Mockchain
+    Mockchain(..),
+    genMockchain,
+    -- * Transactions
+    genInitialTransaction,
+    genValidTransaction
+    ) where
+
+import           Data.Map              (Map)
+import qualified Data.Map              as Map
+import           Data.Maybe            (fromMaybe)
+import           Hedgehog
+import qualified Hedgehog.Gen          as Gen
+import qualified Hedgehog.Range        as Range
+
+import           Wallet.Emulator.Types
+import           Wallet.UTXO
+
+-- | Blockchain for testing the emulator implementation and traces.
+--
+--   To avoid having to rely on functions from the implementation of
+--   wallet-api (in particular, `Wallet.UTXO.unspentOutputs`) we note the
+--   unspent outputs of the chain when it is first created.
+data Mockchain = Mockchain {
+    mockchainBlockchain :: Blockchain,
+    mockchainUtxo       :: Map TxOutRef TxOut
+    } deriving Show
+
+-- | Generate a mockchain
+--
+--   TODO: Generate more than 1 txn
+genMockchain :: MonadGen m
+    => m Mockchain
+genMockchain = do
+    (txn, ot) <- genInitialTransaction
+    let txId = hashTx txn
+    pure $ Mockchain {
+        mockchainBlockchain = [[txn]],
+        mockchainUtxo = Map.singleton (TxOutRef txId 0) ot
+        }
+
+-- | A transaction with no inputs that forges some value (to be used at the
+--   beginning of a blockchain)
+genInitialTransaction :: MonadGen m
+    => m (Tx, TxOut)
+genInitialTransaction = do
+    vl <- Value <$> Gen.integral (Range.linear 1 1000000)
+    let o = simpleOutput vl
+    pure (Tx {
+        txInputs = [],
+        txOutputs = [o],
+        txForge = vl,
+        txFee = 0
+        }, o)
+
+-- | Generate a valid transaction, using the unspent outputs provided.
+--   Fails if the there are no unspent outputs, or if the total value
+--   of the unspent outputs is smaller than the minimum fee (1)
+genValidTransaction :: MonadGen m
+    => Blockchain
+    -> Map TxOutRef TxOut
+    -> m Tx
+genValidTransaction bc ops = do
+    -- Take a random number of UTXO from the input
+    nUtxo <- if Map.null ops
+             then Gen.discard
+             else Gen.int (Range.linear 1 (Map.size ops))
+    let inputs = fmap simpleInput
+            $ take nUtxo
+            $ fmap fst
+            $ Map.toList ops
+        totalVal = sum (map (fromMaybe 0 . value bc . txInRef) inputs)
+        minFee = 1
+    fee <- Gen.integral (Range.linear minFee totalVal)
+    if fee < totalVal
+        then pure $ Tx {
+                txInputs = inputs,
+                txOutputs = [simpleOutput $ totalVal - fee],
+                txForge = 0,
+                txFee = fee
+            }
+        else Gen.discard
+

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -1,0 +1,75 @@
+module Main(main) where
+
+import           Control.Monad.Operational  as Op
+import           Control.Monad.State        (runState)
+import           Control.Monad.Trans.Except (runExceptT)
+import           Data.Either                (isLeft, isRight)
+import           Generators                 (Mockchain (..))
+import qualified Generators                 as Gen
+import           Hedgehog                   (Property, forAll, property)
+import qualified Hedgehog
+import           Test.Tasty
+import           Test.Tasty.Hedgehog        (testProperty)
+
+import           Wallet.Emulator
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "all tests" [
+    testGroup "UTXO model" [
+        testProperty "initial transaction is valid" initialTxnValid,
+        testProperty "compute UTxO of trivial blockchain" utxo,
+        testProperty "validate transaction" txnValid
+        ],
+    testGroup "traces" [
+        testProperty "accept valid txn" validTrace,
+        testProperty "reject invalid txn" invalidTrace
+        ]
+    ]
+
+initialTxnValid :: Property
+initialTxnValid = property $ do
+    (i, _) <- forAll Gen.genInitialTransaction
+    Hedgehog.assert (validTx i [])
+
+utxo :: Property
+utxo = property $ do
+    Mockchain chain o <- forAll Gen.genMockchain
+    Hedgehog.assert (unspentOutputs chain == o)
+
+txnValid :: Property
+txnValid = property $ do
+    Mockchain chain o <- forAll Gen.genMockchain
+    txn <- forAll $ Gen.genValidTransaction chain o
+    Hedgehog.assert (validTx txn chain)
+
+-- | Submit a transaction to the blockchain and assert that it has been valided
+simpleTrace :: Tx -> Trace ()
+simpleTrace txn = do
+    [txn'] <- Op.singleton $ WalletAction (Wallet 1) $ submitTxn txn
+    block <- Op.singleton BlockchainActions
+    Op.singleton $ Assertion $ isValidated txn'
+
+validTrace :: Property
+validTrace = property $ do
+    Mockchain chain o <- forAll Gen.genMockchain
+    txn <- forAll $ Gen.genValidTransaction chain o
+    let trace = simpleTrace txn
+        emState = emulatorState chain
+        (result, st) = runState (runExceptT $ process trace) emState
+    Hedgehog.assert (isRight result)
+    Hedgehog.assert ([] == emTxPool st)
+
+invalidTrace :: Property
+invalidTrace = property $ do
+    Mockchain chain o <- forAll Gen.genMockchain
+    txn <- forAll $ Gen.genValidTransaction chain o
+    let invalidTxn = txn { txFee = 0 }
+        trace = simpleTrace invalidTxn
+        emState = emulatorState chain
+        (result, st) = runState (runExceptT $ process trace) emState
+    Hedgehog.assert (isLeft result)
+    Hedgehog.assert ([] == emTxPool st)
+

--- a/wallet-api/wallet-api.cabal
+++ b/wallet-api/wallet-api.cabal
@@ -19,7 +19,9 @@ source-repository head
 
 library
     exposed-modules:
-        Wallet.Emulator.Types
+        Wallet.Emulator,
+        Wallet.Emulator.Types,
+        Wallet.UTXO
     other-modules:
     hs-source-dirs: src
     default-language: Haskell2010
@@ -49,4 +51,9 @@ library
         bytestring -any,
         text -any,
         prettyprinter -any,
-        mmorph -any
+        mmorph -any,
+        cryptonite -any,
+        bytestring -any,
+        memory -any,
+        core-to-plc -any,
+        cborg -any

--- a/wallet-api/wallet-api.cabal
+++ b/wallet-api/wallet-api.cabal
@@ -57,3 +57,22 @@ library
         memory -any,
         core-to-plc -any,
         cborg -any
+
+test-suite wallet-api
+    default-language: Haskell2010
+    hs-source-dirs: test
+    type: exitcode-stdio-1.0
+    main-is: Spec.hs
+    other-modules: Generators
+    build-depends:
+        base >=4.9 && <5,
+        bytestring -any,
+        containers -any,
+        hedgehog -any,
+        mtl -any,
+        operational -any,
+        tasty -any,
+        tasty-hedgehog -any,
+        text -any,
+        transformers -any,
+        wallet-api -any


### PR DESCRIPTION
* Add UTXO transaction types based on the code docs/model/UTxO.hsproj
* The main changes to this model are
  a) Use actual PlcCode types for scripts
  b) Add data scripts and make sure that scripts/script hashes are in
     the correct place
* We can now properly validate transactions in the emulator

(the next PR will be importing the wallet reference implementation)