### PR TITLE
core-to-plc: avoid lazy case expressions where possible

### DIFF
--- a/core-to-plc/src/Language/Plutus/CoreToPLC.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC.hs
@@ -305,7 +305,7 @@ More generally, we can compile case expressions (of which an if expression is on
 a unit argument and apply it at the end.
 
 However, we apply an important optimization: we only need to do this if it is not the case that
-all the case expressions are branches. In the common case they *will* be, so this gives us
+all the case expressions are values. In the common case they *will* be, so this gives us
 significantly better codegen a lot of the time.
 
 The check we do is:

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Laziness.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Laziness.hs
@@ -26,3 +26,12 @@ delayType orig = PLC.TyFun () <$> liftQuote Unit.getBuiltinUnit <*> pure orig
 
 force :: MonadQuote m => PLC.Term PLC.TyName PLC.Name () -> m (PLC.Term PLC.TyName PLC.Name ())
 force thunk = PLC.Apply () thunk <$> liftQuote Unit.getBuiltinUnitval
+
+maybeDelay :: MonadQuote m => Bool -> PLC.Term PLC.TyName PLC.Name () -> m (PLC.Term PLC.TyName PLC.Name ())
+maybeDelay yes t = if yes then delay t else pure t
+
+maybeDelayType :: MonadQuote m => Bool -> PLC.Type PLC.TyName () -> m (PLC.Type PLC.TyName ())
+maybeDelayType yes t = if yes then delayType t else pure t
+
+maybeForce :: MonadQuote m => Bool -> PLC.Term PLC.TyName PLC.Name () -> m (PLC.Term PLC.TyName PLC.Name ())
+maybeForce yes t = if yes then force t else pure t

--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -128,6 +128,7 @@ monoData = testGroup "Monomorphic data" [
   , golden "monoConstructed" monoConstructed
   , golden "monoCase" monoCase
   , golden "defaultCase" defaultCase
+  , golden "nonValueCase" nonValueCase
   , golden "synonym" synonym
   ]
 
@@ -152,6 +153,10 @@ monoCase = plc (\(x :: MyMonoData) -> case x of { Mono1 a b -> b;  Mono2 a -> a;
 
 defaultCase :: PlcCode
 defaultCase = plc (\(x :: MyMonoData) -> case x of { Mono2 a -> a ; _ -> 1; })
+
+-- must be compiled with a lazy case
+nonValueCase :: PlcCode
+nonValueCase = plc (\(x :: MyEnum) -> case x of { Enum1 -> 1::Int ; Enum2 -> Prims.error (); })
 
 type Synonym = Int
 

--- a/core-to-plc/test/defaultCase.plc.golden
+++ b/core-to-plc/test/defaultCase.plc.golden
@@ -5,33 +5,16 @@
     [
       [
         [
-          [
-            {
-              ds_1 (fun (all a_2 (type) (fun a_2 a_2)) [(con integer) (con 64)])
-            }
-            (lam
-              default_arg0_5
-              [(con integer) (con 64)]
-              (lam
-                default_arg1_6
-                [(con integer) (con 64)]
-                (lam thunk_3 (all a_4 (type) (fun a_4 a_4)) (con 64 ! 1))
-              )
-            )
-          ]
+          { ds_1 [(con integer) (con 64)] }
           (lam
-            a_7
+            default_arg0_2
             [(con integer) (con 64)]
-            (lam thunk_8 (all a_9 (type) (fun a_9 a_9)) a_7)
+            (lam default_arg1_3 [(con integer) (con 64)] (con 64 ! 1))
           )
         ]
-        (lam
-          default_arg0_12
-          [(con integer) (con 64)]
-          (lam thunk_10 (all a_11 (type) (fun a_11 a_11)) (con 64 ! 1))
-        )
+        (lam a_4 [(con integer) (con 64)] a_4)
       ]
-      (abs a_13 (type) (lam x_14 a_13 x_14))
+      (lam default_arg0_5 [(con integer) (con 64)] (con 64 ! 1))
     ]
   )
 )

--- a/core-to-plc/test/monoCase.plc.golden
+++ b/core-to-plc/test/monoCase.plc.golden
@@ -5,33 +5,14 @@
     [
       [
         [
-          [
-            {
-              ds_1 (fun (all a_2 (type) (fun a_2 a_2)) [(con integer) (con 64)])
-            }
-            (lam
-              a_3
-              [(con integer) (con 64)]
-              (lam
-                b_4
-                [(con integer) (con 64)]
-                (lam thunk_5 (all a_6 (type) (fun a_6 a_6)) b_4)
-              )
-            )
-          ]
+          { ds_1 [(con integer) (con 64)] }
           (lam
-            a_7
-            [(con integer) (con 64)]
-            (lam thunk_8 (all a_9 (type) (fun a_9 a_9)) a_7)
+            a_2 [(con integer) (con 64)] (lam b_3 [(con integer) (con 64)] b_3)
           )
         ]
-        (lam
-          a_10
-          [(con integer) (con 64)]
-          (lam thunk_11 (all a_12 (type) (fun a_12 a_12)) a_10)
-        )
+        (lam a_4 [(con integer) (con 64)] a_4)
       ]
-      (abs a_13 (type) (lam x_14 a_13 x_14))
+      (lam a_5 [(con integer) (con 64)] a_5)
     ]
   )
 )

--- a/core-to-plc/test/nonValueCase.plc.golden
+++ b/core-to-plc/test/nonValueCase.plc.golden
@@ -1,0 +1,32 @@
+(program 1.0.0
+  (lam
+    ds_1
+    (all MyEnum_matchOut_0 (type) (fun MyEnum_matchOut_0 (fun MyEnum_matchOut_0 MyEnum_matchOut_0)))
+    [
+      [
+        [
+          { ds_1 (fun (all a_7 (type) (fun a_7 a_7)) [(con integer) (con 64)]) }
+          (lam thunk_8 (all a_9 (type) (fun a_9 a_9)) (con 64 ! 1))
+        ]
+        (lam
+          thunk_15
+          (all a_16 (type) (fun a_16 a_16))
+          [
+            {
+              (abs
+                e_10
+                (type)
+                (lam thunk_11 (all a_12 (type) (fun a_12 a_12)) (error e_10))
+              )
+              [(con integer) (con 64)]
+            }
+            (abs
+              p_matchOut_13 (type) (lam bad_name_14 p_matchOut_13 bad_name_14)
+            )
+          ]
+        )
+      ]
+      (abs a_17 (type) (lam x_18 a_17 x_18))
+    ]
+  )
+)

--- a/core-to-plc/test/tupleMatch.plc.golden
+++ b/core-to-plc/test/tupleMatch.plc.golden
@@ -3,19 +3,8 @@
     ds_3
     [[(lam a_0 (type) (lam b_1 (type) (all p_matchOut_2 (type) (fun (fun a_0 (fun b_1 p_matchOut_2)) p_matchOut_2)))) [(con integer) (con 64)]] [(con integer) (con 64)]]
     [
-      [
-        { ds_3 (fun (all a_4 (type) (fun a_4 a_4)) [(con integer) (con 64)]) }
-        (lam
-          a_5
-          [(con integer) (con 64)]
-          (lam
-            b_6
-            [(con integer) (con 64)]
-            (lam thunk_7 (all a_8 (type) (fun a_8 a_8)) a_5)
-          )
-        )
-      ]
-      (abs a_9 (type) (lam x_10 a_9 x_10))
+      { ds_3 [(con integer) (con 64)] }
+      (lam a_4 [(con integer) (con 64)] (lam b_5 [(con integer) (con 64)] a_4))
     ]
   )
 )

--- a/core-to-plc/test/void.plc.golden
+++ b/core-to-plc/test/void.plc.golden
@@ -30,71 +30,71 @@
                               [
                                 {
                                   x_25
-                                  (fun (all a_39 (type) (fun a_39 a_39)) (all Bool_matchOut_38 (type) (fun Bool_matchOut_38 (fun Bool_matchOut_38 Bool_matchOut_38))))
+                                  (fun (all a_62 (type) (fun a_62 a_62)) (all Bool_matchOut_61 (type) (fun Bool_matchOut_61 (fun Bool_matchOut_61 Bool_matchOut_61))))
                                 }
                                 (lam
-                                  thunk_43
-                                  (all a_44 (type) (fun a_44 a_44))
+                                  thunk_66
+                                  (all a_67 (type) (fun a_67 a_67))
                                   [
                                     fail_37
                                     (abs
-                                      e_40
+                                      e_63
                                       (type)
                                       (lam
-                                        thunk_41
-                                        (all a_42 (type) (fun a_42 a_42))
-                                        (error e_40)
+                                        thunk_64
+                                        (all a_65 (type) (fun a_65 a_65))
+                                        (error e_63)
                                       )
                                     )
                                   ]
                                 )
                               ]
                               (lam
-                                thunk_59
-                                (all a_60 (type) (fun a_60 a_60))
+                                thunk_88
+                                (all a_89 (type) (fun a_89 a_89))
                                 [
                                   [
                                     [
                                       {
                                         y_27
-                                        (fun (all a_46 (type) (fun a_46 a_46)) (all Bool_matchOut_45 (type) (fun Bool_matchOut_45 (fun Bool_matchOut_45 Bool_matchOut_45))))
+                                        (fun (all a_75 (type) (fun a_75 a_75)) (all Bool_matchOut_74 (type) (fun Bool_matchOut_74 (fun Bool_matchOut_74 Bool_matchOut_74))))
                                       }
                                       (lam
-                                        thunk_50
-                                        (all a_51 (type) (fun a_51 a_51))
+                                        thunk_79
+                                        (all a_80 (type) (fun a_80 a_80))
                                         [
                                           fail_37
                                           (abs
-                                            e_47
+                                            e_76
                                             (type)
                                             (lam
-                                              thunk_48
-                                              (all a_49 (type) (fun a_49 a_49))
-                                              (error e_47)
+                                              thunk_77
+                                              (all a_78 (type) (fun a_78 a_78))
+                                              (error e_76)
                                             )
                                           )
                                         ]
                                       )
                                     ]
                                     (lam
-                                      thunk_55
-                                      (all a_56 (type) (fun a_56 a_56))
+                                      thunk_84
+                                      (all a_85 (type) (fun a_85 a_85))
                                       (abs
-                                        Bool_matchOut_52
+                                        Bool_matchOut_81
                                         (type)
                                         (lam
-                                          False_53
-                                          Bool_matchOut_52
-                                          (lam True_54 Bool_matchOut_52 True_54)
+                                          False_82
+                                          Bool_matchOut_81
+                                          (lam True_83 Bool_matchOut_81 True_83)
                                         )
                                       )
                                     )
                                   ]
-                                  (abs a_57 (type) (lam x_58 a_57 x_58))
+                                  (abs a_86 (type) (lam x_87 a_86 x_87))
                                 ]
                               )
                             ]
-                            (abs a_61 (type) (lam x_62 a_61 x_62))
+                            (abs a_90 (type) (lam x_91 a_90 x_91))
                           ]
                         )
                         (lam

--- a/plutus-th/test/and.plc.golden
+++ b/plutus-th/test/and.plc.golden
@@ -5,42 +5,28 @@
       (all Bool_matchOut_0 (type) (fun Bool_matchOut_0 (fun Bool_matchOut_0 Bool_matchOut_0)))
       [
         [
-          [
-            {
-              ds_1
-              (fun (all a_3 (type) (fun a_3 a_3)) (all Bool_matchOut_2 (type) (fun Bool_matchOut_2 (fun Bool_matchOut_2 Bool_matchOut_2))))
-            }
-            (lam
-              thunk_7
-              (all a_8 (type) (fun a_8 a_8))
-              (abs
-                Bool_matchOut_4
-                (type)
-                (lam
-                  False_5 Bool_matchOut_4 (lam True_6 Bool_matchOut_4 False_5)
-                )
-              )
-            )
-          ]
-          (lam
-            thunk_12
-            (all a_13 (type) (fun a_13 a_13))
-            (abs
-              Bool_matchOut_9
-              (type)
-              (lam
-                False_10 Bool_matchOut_9 (lam True_11 Bool_matchOut_9 True_11)
-              )
+          {
+            ds_1
+            (all Bool_matchOut_8 (type) (fun Bool_matchOut_8 (fun Bool_matchOut_8 Bool_matchOut_8)))
+          }
+          (abs
+            Bool_matchOut_9
+            (type)
+            (lam False_10 Bool_matchOut_9 (lam True_11 Bool_matchOut_9 False_10)
             )
           )
         ]
-        (abs a_14 (type) (lam x_15 a_14 x_15))
+        (abs
+          Bool_matchOut_12
+          (type)
+          (lam False_13 Bool_matchOut_12 (lam True_14 Bool_matchOut_12 True_14))
+        )
       ]
     )
     (abs
-      Bool_matchOut_16
+      Bool_matchOut_15
       (type)
-      (lam False_17 Bool_matchOut_16 (lam True_18 Bool_matchOut_16 False_17))
+      (lam False_16 Bool_matchOut_15 (lam True_17 Bool_matchOut_15 False_16))
     )
   ]
 )

--- a/plutus-th/test/simple.plc.golden
+++ b/plutus-th/test/simple.plc.golden
@@ -2,15 +2,6 @@
   (lam
     ds_1
     (all Bool_matchOut_0 (type) (fun Bool_matchOut_0 (fun Bool_matchOut_0 Bool_matchOut_0)))
-    [
-      [
-        [
-          { ds_1 (fun (all a_2 (type) (fun a_2 a_2)) [(con integer) (con 64)]) }
-          (lam thunk_3 (all a_4 (type) (fun a_4 a_4)) (con 64 ! 2))
-        ]
-        (lam thunk_5 (all a_6 (type) (fun a_6 a_6)) (con 64 ! 1))
-      ]
-      (abs a_7 (type) (lam x_8 a_7 x_8))
-    ]
+    [ [ { ds_1 [(con integer) (con 64)] } (con 64 ! 2) ] (con 64 ! 1) ]
   )
 )


### PR DESCRIPTION
I realised that we only actually *need* to compile case expressions lazily when they might unexpectedly evaluate some non-value terms. However, in the common case (where the datatype branch has arguments) we are guaranteed to be passing a lambda. So the only times we might need to do this are for alternatives for constructors without arguments or (potentially) default cases. 

This is then fairly easy to check. The result shaves potentially quite a bit of most case expressions, which is nice. I think it's worth it - we don't get many codegen wins! But it does make our codegen less uniform, which is potentially bad.

(Interestingly, the `void` test case doesn't benefit, because it gets some "impossible" pattern match branches. These have evaluations in their RHSs - which will indeed evaluate to error! So we have to compile it lazily there.)