### PR TITLE
Revert "remove ignored hint"

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -21,6 +21,8 @@
 - ignore: {name: Redundant $, within: [Evaluation.Constant.Success, Language.PlutusCore.Generators.Internal.TypedBuiltinGen]}
 # this is rarely an improvement, also ignored in cardano
 - ignore: {name: Move brackets to avoid $}
+# this aids clarity since you can name the parameters
+- ignore: {name: Avoid lambda}
 
 - fixity: infixr 8 .*
 - fixity: infixr 3 ***


### PR DESCRIPTION
Reverts input-output-hk/plutus-prototype#134

Here's an example 
```
let tuple = foldl' (\acc rhs -> PLC.Apply () acc rhs) tupleConstructor rhss
```

I *could* delete the lambda arguments, but I think that's less clear since it's a coincidence that `PLC.Apply` happens to take the argument s this way around.