### PR TITLE
wallet emulator import & API

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -78329,18 +78329,11 @@ transformers
 ];
 testHaskellDepends = [
 base
-bytestring
 containers
-core-to-plc
-cryptonite
 hedgehog
-mtl
-operational
-plutus-th
 tasty
 tasty-hedgehog
 text
-transformers
 ];
 doHaddock = false;
 description = "Wallet API";

--- a/wallet-api/test/Generators.hs
+++ b/wallet-api/test/Generators.hs
@@ -1,22 +1,61 @@
+{-# LANGUAGE RecordWildCards #-}
 module Generators(
     -- * Mockchain
     Mockchain(..),
     genMockchain,
+    genMockchain',
+    emptyChain,
+    GeneratorModel(..),
+    generatorModel,
     -- * Transactions
+    FeeEstimator(..),
+    constantFee,
+    genValidTransaction,
+    genValidTransaction',
     genInitialTransaction,
-    genValidTransaction
+    -- * Assertions
+    assertValid,
+    -- * Etc.
+    runTrace,
+    splitVal
     ) where
 
-import           Data.Map              (Map)
-import qualified Data.Map              as Map
-import           Data.Maybe            (fromMaybe)
-import qualified Data.Set              as Set
+import           Control.Monad.State        (runState)
+import           Control.Monad.Trans.Except (runExceptT)
+import           Data.Bifunctor             (Bifunctor(..))
+import           Data.Map                   (Map)
+import qualified Data.Map                   as Map
+import           Data.Maybe                 (fromMaybe)
+import           Data.Set                   (Set)
+import qualified Data.Set                   as Set
+import           GHC.Stack                  (HasCallStack)
 import           Hedgehog
-import qualified Hedgehog.Gen          as Gen
-import qualified Hedgehog.Range        as Range
+import qualified Hedgehog.Gen               as Gen
+import qualified Hedgehog.Range             as Range
 
 import           Wallet.Emulator.Types
 import           Wallet.UTXO
+
+data GeneratorModel = GeneratorModel {
+    -- | Max. number of outputs for the initial transaction
+    gmNumOutputs      :: Int,
+    -- | Value created at the beginning of the blockchain
+    gmInitialBalance :: Value
+    } deriving Show
+
+-- | A generator model with some sensible defaults
+generatorModel :: GeneratorModel
+generatorModel = GeneratorModel {
+    gmNumOutputs = 2,
+    gmInitialBalance = 100000
+    }
+
+-- | Estimate a transaction fee based on the number of its inputs and outputs.
+newtype FeeEstimator = FeeEstimator { estimateFee :: Int -> Int -> Value }
+
+-- | A constant fee for all transactions
+constantFee :: Value -> FeeEstimator
+constantFee = FeeEstimator . const . const
 
 -- | Blockchain for testing the emulator implementation and traces.
 --
@@ -28,30 +67,41 @@ data Mockchain = Mockchain {
     mockchainUtxo       :: Map TxOutRef TxOut
     } deriving Show
 
+-- | The empty mockchain
+emptyChain :: Mockchain
+emptyChain = Mockchain [] Map.empty
+
 -- | Generate a mockchain
 --
 --   TODO: Generate more than 1 txn
-genMockchain :: MonadGen m
-    => m Mockchain
-genMockchain = do
-    (txn, ot) <- genInitialTransaction
+genMockchain' :: MonadGen m
+    => GeneratorModel
+    -> m Mockchain
+genMockchain' gm = do
+    (txn, ot) <- genInitialTransaction gm
     let txId = hashTx txn
     pure Mockchain {
         mockchainBlockchain = [[txn]],
-        mockchainUtxo = Map.singleton (TxOutRef txId 0) ot
+        mockchainUtxo = Map.fromList $ first (TxOutRef txId) <$> zip [0..] ot
         }
+
+-- | Generate a mockchain using the default [[GeneratorModel]]
+--
+genMockchain :: MonadGen m => m Mockchain
+genMockchain = genMockchain' generatorModel
 
 -- | A transaction with no inputs that forges some value (to be used at the
 --   beginning of a blockchain)
 genInitialTransaction :: MonadGen m
-    => m (Tx, TxOut)
-genInitialTransaction = do
-    vl <- Value <$> Gen.integral (Range.linear 1 1000000)
-    let o = simpleOutput vl
+    => GeneratorModel
+    -> m (Tx, [TxOut])
+genInitialTransaction GeneratorModel{..} = do
+    vls <- splitVal gmNumOutputs gmInitialBalance
+    let o = simpleOutput <$> vls
     pure (Tx {
         txInputs = Set.empty,
-        txOutputs = [o],
-        txForge = vl,
+        txOutputs = o,
+        txForge = gmInitialBalance,
         txFee = 0
         }, o)
 
@@ -59,27 +109,59 @@ genInitialTransaction = do
 --   Fails if the there are no unspent outputs, or if the total value
 --   of the unspent outputs is smaller than the minimum fee (1)
 genValidTransaction :: MonadGen m
-    => Blockchain
-    -> Map TxOutRef TxOut
+    => Mockchain
     -> m Tx
-genValidTransaction bc ops = do
+genValidTransaction = genValidTransaction' (constantFee 1)
+
+-- | Generate a valid transaction, using the unspent outputs provided.
+--   Fails if the there are no unspent outputs, or if the total value
+--   of the unspent outputs is smaller than the estimated fee.
+genValidTransaction' :: MonadGen m
+    => FeeEstimator
+    -> Mockchain
+    -> m Tx
+genValidTransaction' f (Mockchain bc ops) = do
     -- Take a random number of UTXO from the input
     nUtxo <- if Map.null ops
-             then Gen.discard
-             else Gen.int (Range.linear 1 (Map.size ops))
-    let inputs = fmap simpleInput
-            $ take nUtxo
-            $ fst
-            <$> Map.toList ops
+                then Gen.discard
+                else Gen.int (Range.linear 1 (Map.size ops))
+    let inputs = simpleInput . fst <$> (take nUtxo $ Map.toList ops)
         totalVal = sum (map (fromMaybe 0 . value bc . txInRef) inputs)
-        minFee = 1
-    fee <- Gen.integral (Range.linear minFee totalVal)
+        fee = estimateFee f (length inputs) 3
     if fee < totalVal
-        then pure Tx {
-                txInputs = Set.fromList inputs,
-                txOutputs = [simpleOutput $ totalVal - fee],
-                txForge = 0,
-                txFee = fee
-            }
+        then do
+            outVals <- splitVal 3 (totalVal - fee)
+            pure Tx {
+                    txInputs = Set.fromList inputs,
+                    txOutputs = simpleOutput <$> outVals,
+                    txForge = 0,
+                    txFee = fee }
         else Gen.discard
 
+-- | Assert that a transaction is valid in a chain
+assertValid :: (MonadTest m, HasCallStack)
+    => Tx
+    -> Mockchain
+    -> m ()
+assertValid tx (Mockchain chain _) = Hedgehog.assert (validTx tx chain)
+
+-- | Run an emulator trace on a mockchain
+runTrace ::
+    Mockchain
+    -> Trace a
+    -> (Either AssertionError a, EmulatorState)
+runTrace (Mockchain chain _) t = runState (runExceptT $ process t) emState where
+    emState = emulatorState chain
+
+-- | Split a value into max. n positive-valued parts such that the sum of the
+--   parts equals the original value.
+splitVal :: (MonadGen m, Integral n) => Int -> n -> m [n]
+splitVal mx init = go 0 0 [] where
+    go i c l =
+        if i >= pred mx
+        then pure $ (init - c) : l
+        else do
+            v <- Gen.integral (Range.linear 1 $ init - c)
+            if v + c == init
+            then pure $ v : l
+            else go (succ i) (v + c) (v : l)

--- a/wallet-api/test/Generators.hs
+++ b/wallet-api/test/Generators.hs
@@ -16,29 +16,26 @@ module Generators(
     -- * Assertions
     assertValid,
     -- * Etc.
-    runTrace,
+    Generators.runTrace,
     splitVal
     ) where
 
-import           Control.Monad.State        (runState)
-import           Control.Monad.Trans.Except (runExceptT)
-import           Data.Bifunctor             (Bifunctor(..))
-import           Data.Map                   (Map)
-import qualified Data.Map                   as Map
-import           Data.Maybe                 (fromMaybe)
-import           Data.Set                   (Set)
-import qualified Data.Set                   as Set
-import           GHC.Stack                  (HasCallStack)
+import           Data.Bifunctor  (Bifunctor (..))
+import           Data.Map        (Map)
+import qualified Data.Map        as Map
+import           Data.Maybe      (fromMaybe)
+import           Data.Set        (Set)
+import qualified Data.Set        as Set
+import           GHC.Stack       (HasCallStack)
 import           Hedgehog
-import qualified Hedgehog.Gen               as Gen
-import qualified Hedgehog.Range             as Range
+import qualified Hedgehog.Gen    as Gen
+import qualified Hedgehog.Range  as Range
 
-import           Wallet.Emulator.Types
-import           Wallet.UTXO
+import           Wallet.Emulator as Emulator
 
 data GeneratorModel = GeneratorModel {
     -- | Max. number of outputs for the initial transaction
-    gmNumOutputs      :: Int,
+    gmNumOutputs     :: Int,
     -- | Value created at the beginning of the blockchain
     gmInitialBalance :: Value
     } deriving Show
@@ -150,8 +147,7 @@ runTrace ::
     Mockchain
     -> Trace a
     -> (Either AssertionError a, EmulatorState)
-runTrace (Mockchain chain _) t = runState (runExceptT $ process t) emState where
-    emState = emulatorState chain
+runTrace (Mockchain chain _) = Emulator.runTrace chain
 
 -- | Split a value into max. n positive-valued parts such that the sum of the
 --   parts equals the original value.

--- a/wallet-api/test/Generators.hs
+++ b/wallet-api/test/Generators.hs
@@ -10,6 +10,7 @@ module Generators(
 import           Data.Map              (Map)
 import qualified Data.Map              as Map
 import           Data.Maybe            (fromMaybe)
+import qualified Data.Set              as Set
 import           Hedgehog
 import qualified Hedgehog.Gen          as Gen
 import qualified Hedgehog.Range        as Range
@@ -48,7 +49,7 @@ genInitialTransaction = do
     vl <- Value <$> Gen.integral (Range.linear 1 1000000)
     let o = simpleOutput vl
     pure (Tx {
-        txInputs = [],
+        txInputs = Set.empty,
         txOutputs = [o],
         txForge = vl,
         txFee = 0
@@ -75,7 +76,7 @@ genValidTransaction bc ops = do
     fee <- Gen.integral (Range.linear minFee totalVal)
     if fee < totalVal
         then pure Tx {
-                txInputs = inputs,
+                txInputs = Set.fromList inputs,
                 txOutputs = [simpleOutput $ totalVal - fee],
                 txForge = 0,
                 txFee = fee

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -8,6 +8,8 @@ import           Generators                 (Mockchain (..))
 import qualified Generators                 as Gen
 import           Hedgehog                   (Property, forAll, property)
 import qualified Hedgehog
+import qualified Hedgehog.Gen               as Gen
+import qualified Hedgehog.Range             as Range
 import           Test.Tasty
 import           Test.Tasty.Hedgehog        (testProperty)
 
@@ -26,13 +28,16 @@ tests = testGroup "all tests" [
     testGroup "traces" [
         testProperty "accept valid txn" validTrace,
         testProperty "reject invalid txn" invalidTrace
+        ],
+    testGroup "Etc." [
+        testProperty "splitVal" splitVal
         ]
     ]
 
 initialTxnValid :: Property
 initialTxnValid = property $ do
-    (i, _) <- forAll Gen.genInitialTransaction
-    Hedgehog.assert (validTx i [])
+    (i, _) <- forAll $ Gen.genInitialTransaction Gen.generatorModel
+    Gen.assertValid i Gen.emptyChain
 
 utxo :: Property
 utxo = property $ do
@@ -41,11 +46,12 @@ utxo = property $ do
 
 txnValid :: Property
 txnValid = property $ do
-    Mockchain chain o <- forAll Gen.genMockchain
-    txn <- forAll $ Gen.genValidTransaction chain o
-    Hedgehog.assert (validTx txn chain)
+    m <- forAll Gen.genMockchain
+    txn <- forAll $ Gen.genValidTransaction m
+    Gen.assertValid txn m
 
--- | Submit a transaction to the blockchain and assert that it has been valided
+-- | Submit a transaction to the blockchain and assert that it has been 
+--   validated
 simpleTrace :: Tx -> Trace ()
 simpleTrace txn = do
     [txn'] <- Op.singleton $ WalletAction (Wallet 1) $ submitTxn txn
@@ -54,22 +60,25 @@ simpleTrace txn = do
 
 validTrace :: Property
 validTrace = property $ do
-    Mockchain chain o <- forAll Gen.genMockchain
-    txn <- forAll $ Gen.genValidTransaction chain o
-    let trace = simpleTrace txn
-        emState = emulatorState chain
-        (result, st) = runState (runExceptT $ process trace) emState
+    m <- forAll Gen.genMockchain
+    txn <- forAll $ Gen.genValidTransaction m
+    let (result, st) = Gen.runTrace m $ simpleTrace txn
     Hedgehog.assert (isRight result)
     Hedgehog.assert ([] == emTxPool st)
 
 invalidTrace :: Property
 invalidTrace = property $ do
-    Mockchain chain o <- forAll Gen.genMockchain
-    txn <- forAll $ Gen.genValidTransaction chain o
+    m <- forAll Gen.genMockchain
+    txn <- forAll $ Gen.genValidTransaction m
     let invalidTxn = txn { txFee = 0 }
-        trace = simpleTrace invalidTxn
-        emState = emulatorState chain
-        (result, st) = runState (runExceptT $ process trace) emState
+        (result, st) = Gen.runTrace m $ simpleTrace invalidTxn
     Hedgehog.assert (isLeft result)
     Hedgehog.assert ([] == emTxPool st)
 
+splitVal :: Property
+splitVal = property $ do
+    i <- forAll $ Gen.int $ Range.linear 1 (100000 :: Int)
+    n <- forAll $ Gen.int $ Range.linear 1 100
+    vs <- forAll $ Gen.splitVal n i 
+    Hedgehog.assert $ sum vs == i
+    Hedgehog.assert $ length vs <= n

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -1,17 +1,14 @@
 module Main(main) where
 
-import           Control.Monad.Operational  as Op
-import           Control.Monad.State        (runState)
-import           Control.Monad.Trans.Except (runExceptT)
-import           Data.Either                (isLeft, isRight)
-import           Generators                 (Mockchain (..))
-import qualified Generators                 as Gen
-import           Hedgehog                   (Property, forAll, property)
+import           Data.Either         (isLeft, isRight)
+import           Generators          (Mockchain (..))
+import qualified Generators          as Gen
+import           Hedgehog            (Property, forAll, property)
 import qualified Hedgehog
-import qualified Hedgehog.Gen               as Gen
-import qualified Hedgehog.Range             as Range
+import qualified Hedgehog.Gen        as Gen
+import qualified Hedgehog.Range      as Range
 import           Test.Tasty
-import           Test.Tasty.Hedgehog        (testProperty)
+import           Test.Tasty.Hedgehog (testProperty)
 
 import           Wallet.Emulator
 
@@ -50,13 +47,13 @@ txnValid = property $ do
     txn <- forAll $ Gen.genValidTransaction m
     Gen.assertValid txn m
 
--- | Submit a transaction to the blockchain and assert that it has been 
+-- | Submit a transaction to the blockchain and assert that it has been
 --   validated
 simpleTrace :: Tx -> Trace ()
 simpleTrace txn = do
-    [txn'] <- Op.singleton $ WalletAction (Wallet 1) $ submitTxn txn
-    block <- Op.singleton BlockchainActions
-    Op.singleton $ Assertion $ isValidated txn'
+    [txn'] <- walletAction (Wallet 1) $ submitTxn txn
+    block <- blockchainActions
+    assertion $ isValidated txn'
 
 validTrace :: Property
 validTrace = property $ do
@@ -79,6 +76,6 @@ splitVal :: Property
 splitVal = property $ do
     i <- forAll $ Gen.int $ Range.linear 1 (100000 :: Int)
     n <- forAll $ Gen.int $ Range.linear 1 100
-    vs <- forAll $ Gen.splitVal n i 
+    vs <- forAll $ Gen.splitVal n i
     Hedgehog.assert $ sum vs == i
     Hedgehog.assert $ length vs <= n

--- a/wallet-api/wallet-api.cabal
+++ b/wallet-api/wallet-api.cabal
@@ -66,13 +66,9 @@ test-suite wallet-api
     other-modules: Generators
     build-depends:
         base >=4.9 && <5,
-        bytestring -any,
         containers -any,
         hedgehog -any,
-        mtl -any,
-        operational -any,
         tasty -any,
         tasty-hedgehog -any,
         text -any,
-        transformers -any,
         wallet-api -any


### PR DESCRIPTION
* Change UTXO model in `wallet-api` to match the reference implementation in cardano-sl/new-wallet/test/unit where applicable
* Nicer API for `Wallet.Emulator.Types`
* Generate transactions with multiple outputs in emulator tests; add parameters for mockchain size and fee estimation