### PR TITLE
s_01i -> s_0!i

### DIFF
--- a/plutus-core-spec/figures/PlutusCoreBuiltins.tex
+++ b/plutus-core-spec/figures/PlutusCoreBuiltins.tex
@@ -105,7 +105,7 @@
         %&&\\
         
         \texttt{takeByteString}    &   \forall s_0, s_1 :: size.\ integer_{s_0} \to bytestring_{s_1} \to bytestring_{s_1}   &   s_0!i, s_1!b     & s_1!(take \ i \  b)\\
-        \texttt{dropByteString}    &   \forall s_0, s_1 :: size.\ integer_{s_0} \to bytestring_{s_1} \to bytestring_{s_1}   &   s_01i, s_1!b     & s_1!(drop \ i \  b)\\
+        \texttt{dropByteString}    &   \forall s_0, s_1 :: size.\ integer_{s_0} \to bytestring_{s_1} \to bytestring_{s_1}   &   s_0!i, s_1!b     & s_1!(drop \ i \  b)\\
         %&&\\
         
         \texttt{sha2\_256}         &  \forall s :: size.\ bytestring_s \to bytestring_{\conT{256}}  &   s!b           & 256!(sha2\_256 \  b)\\


### PR DESCRIPTION
Fix a single-character typo.