### PR TITLE
Untyped TH to appease hs-src-exts

### DIFF
--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
@@ -19,8 +19,8 @@ module Language.Plutus.Coordination.Contracts.CrowdFunding (
     ) where
 
 import           Language.Plutus.Coordination.Plutus
-import           Language.Plutus.TH (plutusT)
 import qualified Language.Plutus.CoreToPLC.Primitives as Prim
+import           Language.Plutus.TH                   (plutus)
 
 import           Prelude                              (Bool (..), Either (..), Num (..), Ord (..), succ, sum, ($))
 
@@ -76,7 +76,7 @@ contributionScript _ _  = PlutusTx inner where
 
     --   See note [Contracts and Validator Scripts] in
     --       Language.Plutus.Coordination.Contracts
-    inner = $$(plutusT [|| (\() () p Campaign{..} contribPubKey ->
+    inner = $(plutus [| (\() () p Campaign{..} contribPubKey ->
         let
             -- | Check that a transaction input is signed by the private key of the given
             --   public key.
@@ -119,7 +119,7 @@ contributionScript _ _  = PlutusTx inner where
                         -- were committed by this contributor
                     in refundable
         in
-        if isValid then () else Prim.error ()) ||])
+        if isValid then () else Prim.error ()) |])
 
 -- | Given the campaign data and the output from the contributing transaction,
 --   make a trigger that fires when the transaction can be refunded.
@@ -141,7 +141,7 @@ refund c ref = do
     let scr = contributionScript c (pubKey kp)
         o = TxOutPubKey value (pubKey kp)
         i = txInSign ref scr unitPLC unitPLC kp
-    submitTransaction $ Tx {
+    submitTransaction Tx {
       txInputs = Left i,
       txOutputs = Left o
     } where

--- a/wallet-api/src/Wallet/UTXO.hs
+++ b/wallet-api/src/Wallet/UTXO.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TupleSections   #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections   #-}
 {-# LANGUAGE ViewPatterns    #-}
 {-# OPTIONS -fplugin=Language.Plutus.CoreToPLC.Plugin -fplugin-opt Language.Plutus.CoreToPLC.Plugin:dont-typecheck #-}
 module Wallet.UTXO(
@@ -60,29 +60,29 @@ module Wallet.UTXO(
     encodeTxOut
     ) where
 
-import           Codec.CBOR.Encoding                       (Encoding)
-import qualified Codec.CBOR.Encoding                       as Enc
-import qualified Codec.CBOR.Write                          as Write
-import           Control.Monad                             (join)
+import           Codec.CBOR.Encoding                      (Encoding)
+import qualified Codec.CBOR.Encoding                      as Enc
+import qualified Codec.CBOR.Write                         as Write
+import           Control.Monad                            (join)
 import           Control.Monad.Except
-import           Crypto.Hash                               (Digest, SHA256, hash)
-import qualified Data.ByteArray                            as BA
-import qualified Data.ByteString.Char8                     as BS
-import qualified Data.ByteString.Lazy                      as BSL
-import           Data.Foldable                             (foldMap)
-import           Data.Map                                  (Map)
-import qualified Data.Map                                  as Map
-import           Data.Maybe                                (fromMaybe, listToMaybe, isJust)
-import           Data.Monoid                               (Sum(..))
-import           Data.Semigroup                            (Semigroup (..))
-import qualified Data.Set                                  as Set
+import           Crypto.Hash                              (Digest, SHA256, hash)
+import qualified Data.ByteArray                           as BA
+import qualified Data.ByteString.Char8                    as BS
+import qualified Data.ByteString.Lazy                     as BSL
+import           Data.Foldable                            (foldMap)
+import           Data.Map                                 (Map)
+import qualified Data.Map                                 as Map
+import           Data.Maybe                               (fromMaybe, isJust, listToMaybe)
+import           Data.Monoid                              (Sum (..))
+import           Data.Semigroup                           (Semigroup (..))
+import qualified Data.Set                                 as Set
 
-import           Language.Plutus.CoreToPLC.Plugin          (PlcCode, getSerializedCode, getAst)
-import           Language.Plutus.TH                        (plutusT)
-import           Language.PlutusCore                       (applyProgram, typecheckPipeline)
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Evaluation.CkMachine  (runCk)
+import           Language.Plutus.CoreToPLC.Plugin         (PlcCode, getAst, getSerializedCode)
+import           Language.Plutus.TH                       (plutus)
+import           Language.PlutusCore                      (applyProgram, typecheckPipeline)
+import           Language.PlutusCore.Evaluation.CkMachine (runCk)
 import           Language.PlutusCore.Evaluation.Result
+import           Language.PlutusCore.Quote
 
 {- Note [Serialisation and hashing]
 
@@ -410,15 +410,15 @@ runScript _ (Validator (getAst -> validator)) (Redeemer (getAst -> redeemer)) (D
 
 -- | () as a data script
 unitData :: DataScript
-unitData = DataScript $$(plutusT [|| () ||])
+unitData = DataScript $(plutus [| () |])
 
 -- | \() () -> () as a validator
 emptyValidator :: Validator
-emptyValidator = Validator $$(plutusT [|| \() () -> () ||])
+emptyValidator = Validator $(plutus [| \() () -> () |])
 
 -- | () as a redeemer
 unitRedeemer :: Redeemer
-unitRedeemer = Redeemer $$(plutusT [|| () ||])
+unitRedeemer = Redeemer $(plutus [| () |])
 
 -- | Transaction output locked by the empty validator and unit data scripts.
 simpleOutput :: Value -> TxOut


### PR DESCRIPTION
* Use untyped TH splices to allow hlint and stylish-haskell to work
* see https://github.com/haskell-suite/haskell-src-exts/issues/383
* Unfortunately this reverses some of the formatting changes from c907023