### PR TITLE
language-plutus-core: add useful term construction functions

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -29,6 +29,7 @@
 # annoyingly, 'within' doesn't seem to work if there's a parse error, so we have to blanket
 # ignore it
 - ignore: {name: Parse error}
+- ignore: {name: Eta reduce, within: [Language.PlutusCore.MkPlc]}
 
 - fixity: infixr 8 .*
 - fixity: infixr 3 ***

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Interesting.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Interesting.hs
@@ -8,6 +8,7 @@ module Language.PlutusCore.Generators.Interesting
 import           Language.PlutusCore
 import           Language.PlutusCore.Constant
 import           Language.PlutusCore.Generators
+import           Language.PlutusCore.MkPlc
 import           Language.PlutusCore.StdLib.Data.Bool
 import           Language.PlutusCore.StdLib.Data.Function
 import           Language.PlutusCore.StdLib.Data.List
@@ -33,9 +34,9 @@ getBuiltinNatToInteger :: Natural -> Term TyName Name () -> Quote (Term TyName N
 getBuiltinNatToInteger s n = do
     builtinFoldNat <- getBuiltinFoldNat
     let int = Constant () . BuiltinInt () s
-    return
-        . foldl' (Apply ()) (TyInst () builtinFoldNat $ TyBuiltin () TyInteger)
-        $ [ Apply () (Constant () $ BuiltinName () AddInteger) $ int 1
+    return $
+         mkIterApp (TyInst () builtinFoldNat $ TyBuiltin () TyInteger)
+         [ Apply () (Constant () $ BuiltinName () AddInteger) $ int 1
           , int 0
           , n
           ]
@@ -90,8 +91,8 @@ genIfIntegers = do
     builtinUnit  <- lift getBuiltinUnit
     builtinIf    <- lift getBuiltinIf
     let builtinConstSpec =
-            Apply () $ foldl' (TyInst ()) builtinConst [TyBuiltin () TyInteger, builtinUnit]
-        term = foldl' (Apply ())
+            Apply () $ mkIterInst builtinConst [TyBuiltin () TyInteger, builtinUnit]
+        term = mkIterApp
             (TyInst () builtinIf $ TyBuiltin () TyInteger)
             [b, builtinConstSpec i, builtinConstSpec j]
         value = if bv then iv else jv

--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -36,6 +36,7 @@ library
     exposed-modules:
         Language.PlutusCore
         Language.PlutusCore.Quote
+        Language.PlutusCore.MkPlc
         Language.PlutusCore.TH
         Language.PlutusCore.Evaluation.CkMachine
         Language.PlutusCore.Evaluation.MachineException

--- a/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
+++ b/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
@@ -1,0 +1,81 @@
+
+module Language.PlutusCore.MkPlc where
+
+import           Language.PlutusCore.Name
+import           Language.PlutusCore.Type
+
+import           Data.List                (foldl')
+
+-- | Make a "let-binding" for a term.
+mkTermLet
+    :: name () -- ^ The name for the binding
+    -> Term tyname name () -- ^ The term to be bound
+    -> Type tyname () -- ^ The type of the term
+    -> Term tyname name () -- ^ The body of the let, possibly referencing the name.
+    -> Term tyname name ()
+mkTermLet name bind ty body = Apply () (LamAbs () name ty body) bind
+
+-- | Make a "let-binding" for a type. Note: the body must be a value.
+mkTypeLet
+    :: tyname () -- ^ The name for the binding
+    -> Type tyname () -- ^ The type to be bound
+    -> Kind () -- ^ The kind of the type
+    -> Term tyname name () -- ^ The body of the let, possibly referencing the name.
+    -> Term tyname name ()
+mkTypeLet name bind ty body = TyInst () (TyAbs () name ty body) bind
+
+-- | Make an iterated application.
+mkIterApp
+    :: Term tyname name ()
+    -> [Term tyname name ()]
+    -> Term tyname name ()
+mkIterApp fun args = foldl' (Apply ()) fun args
+
+-- | Make an iterated instantiation.
+mkIterInst
+    :: Term tyname name ()
+    -> [Type tyname ()]
+    -> Term tyname name ()
+mkIterInst abs args = foldl' (TyInst ()) abs args
+
+-- | Lambda abstract a list of names.
+mkIterLamAbs
+    :: [(name (), Type tyname ())]
+    -> Term tyname name ()
+    -> Term tyname name ()
+mkIterLamAbs args body = foldr (\(n, ty) acc -> LamAbs () n ty acc) body args
+
+-- | Type abstract a list of names.
+mkIterTyAbs
+    :: [(tyname (), Kind ())]
+    -> Term tyname name ()
+    -> Term tyname name ()
+mkIterTyAbs args body = foldr (\(n, ty) acc -> TyAbs () n ty acc) body args
+
+-- | Make an iterated type application.
+mkIterTyApp
+    :: Type tyname ()
+    -> [Type tyname ()]
+    -> Type tyname ()
+mkIterTyApp fun args = foldl' (TyApp ()) fun args
+
+-- | Make an iterated function type.
+mkIterTyFun
+    :: [Type tyname ()]
+    -> Type tyname ()
+    -> Type tyname ()
+mkIterTyFun tys target = foldr (\ty acc -> TyFun () ty acc) target tys
+
+-- | Universally quantify a list of names.
+mkIterTyForall
+    :: [(tyname (), Kind ())]
+    -> Type tyname ()
+    -> Type tyname ()
+mkIterTyForall args body = foldr (\(n, k) acc -> TyForall () n k acc) body args
+
+-- | Lambda abstract a list of names.
+mkIterTyLam
+    :: [(tyname (), Kind ())]
+    -> Type tyname ()
+    -> Type tyname ()
+mkIterTyLam args body = foldr (\(n, k) acc -> TyLam () n k acc) body args

--- a/language-plutus-core/src/Language/PlutusCore/Quote.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Quote.hs
@@ -11,6 +11,10 @@ module Language.PlutusCore.Quote (
             , freshUnique
             , freshName
             , freshTyName
+            , freshenName
+            , freshenTyName
+            , withTerm
+            , withType
             , QuoteT
             , Quote
             , MonadQuote
@@ -20,15 +24,17 @@ module Language.PlutusCore.Quote (
             ) where
 
 import           Control.Monad.Except
-import           Control.Monad.Morph      as MM
+import           Control.Monad.Morph       as MM
 import           Control.Monad.Reader
 import           Control.Monad.State
 
-import qualified Data.ByteString.Lazy     as BSL
+import qualified Data.ByteString.Lazy      as BSL
 import           Data.Functor.Identity
-import           Hedgehog                 (GenT)
+import           Hedgehog                  (GenT)
 
+import           Language.PlutusCore.MkPlc
 import           Language.PlutusCore.Name
+import           Language.PlutusCore.Type
 import           PlutusPrelude
 
 -- | The state contains the "next" 'Unique' that should be used for a name
@@ -90,6 +96,26 @@ freshUnique = do
 freshName :: (Monad m) => a -> BSL.ByteString -> QuoteT m (Name a)
 freshName ann str = Name ann str <$> freshUnique
 
+-- | Make a copy of the given 'Name' that is distinct from the old one.
+freshenName :: (Monad m) =>  Name a -> QuoteT m (Name a)
+freshenName (Name ann str _) = Name ann str <$> freshUnique
+
 -- | Get a fresh 'TyName', given the annotation an the name.
 freshTyName :: (Monad m) => a -> BSL.ByteString -> QuoteT m (TyName a)
 freshTyName = fmap TyName .* freshName
+
+-- | Make a copy of the given 'TyName' that is distinct from the old one.
+freshenTyName :: (Monad m) =>  TyName a -> QuoteT m (TyName a)
+freshenTyName (TyName name) = TyName <$> freshenName name
+
+-- | Make a term available under a given name inside a computation.
+withTerm :: (MonadQuote m) => m (Term TyName Name ()) -> m (Type TyName ()) -> m (Name ()) -> (Name () -> m (Term TyName Name ())) -> m (Term TyName Name ())
+withTerm bindM tyM n f = do
+    name <- n
+    mkTermLet name <$> bindM <*> tyM <*> f name
+
+-- | Make a type available under a given name inside a computation. Note: the result of the computation must be a value.
+withType :: (MonadQuote m) => m (Type TyName ()) -> m (Kind ()) -> m (TyName ()) -> (TyName () -> m (Term TyName Name ())) -> m (Term TyName Name ())
+withType bindM kM n f = do
+    name <- n
+    mkTypeLet name <$> bindM <*> kM <*> f name

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/ChurchNat.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/ChurchNat.hs
@@ -7,10 +7,10 @@ module Language.PlutusCore.StdLib.Data.ChurchNat
     , getBuiltinChurchSucc
     ) where
 
+import           Language.PlutusCore.MkPlc
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Quote
 import           Language.PlutusCore.Type
-import           PlutusPrelude
 
 -- | Church-encoded @Nat@ as a PLC type.
 --
@@ -54,7 +54,7 @@ getBuiltinChurchSucc = do
         . LamAbs () z (TyVar () r)
         . LamAbs () f (TyFun () (TyVar () r) $ TyVar () r)
         . Apply () (Var () f)
-        . foldl' (Apply ()) (TyInst () (Var () n) $ TyVar () r)
-        $ [ Var () z
+        $ mkIterApp (TyInst () (Var () n) $ TyVar () r)
+          [ Var () z
           , Var () f
           ]

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Function.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Function.hs
@@ -8,11 +8,11 @@ module Language.PlutusCore.StdLib.Data.Function
     , getBuiltinFix
     ) where
 
+import           Language.PlutusCore.MkPlc
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Quote
 import           Language.PlutusCore.StdLib.Type
 import           Language.PlutusCore.Type
-import           PlutusPrelude
 
 -- | 'const' as a PLC term.
 --
@@ -88,7 +88,7 @@ getBuiltinFix = do
         . wrapSelfFunAB
         . LamAbs () s selfFunAB
         . LamAbs () x (TyVar () a)
-        . foldl' (Apply ()) (Var () f)
-        $ [ Apply () (unrollFunAB unroll2) $ Var () s
+        $ mkIterApp (Var () f)
+          [ Apply () (unrollFunAB unroll2) $ Var () s
           , Var () x
           ]

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/List.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/List.hs
@@ -10,6 +10,7 @@ module Language.PlutusCore.StdLib.Data.List
     , getBuiltinSum
     ) where
 
+import           Language.PlutusCore.MkPlc
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Quote
 import           Language.PlutusCore.StdLib.Data.Function
@@ -80,8 +81,8 @@ getBuiltinCons = do
         . TyAbs () r (Type ())
         . LamAbs () z (TyVar () r)
         . LamAbs () f (TyFun () (TyVar () a) . TyFun () listA $ TyVar () r)
-        . foldl' (Apply ()) (Var () f)
-        $ [ Var () x
+        $ mkIterApp (Var () f)
+          [ Var () x
           , Var () xs
           ]
 
@@ -112,14 +113,14 @@ getBuiltinFoldrList = do
         . TyAbs () r (Type ())
         . LamAbs () f (TyFun () (TyVar () r) . TyFun () (TyVar () a) $ TyVar () r)
         . LamAbs () z (TyVar () r)
-        . Apply () (foldl' (TyInst ()) fix [listA, TyVar () r])
+        . Apply () (mkIterInst fix [listA, TyVar () r])
         . LamAbs () rec (TyFun () listA $ TyVar () r)
         . LamAbs () xs listA
         . Apply () (Apply () (TyInst () (Unwrap () (Var () xs)) $ TyVar () r) $ Var () z)
         . LamAbs () x (TyVar () a)
         . LamAbs () xs' listA
-        . foldl' (Apply ()) (Var () f)
-        $ [ Apply () (Var () rec) $ Var () xs'
+        $ mkIterApp (Var () f)
+          [ Apply () (Var () rec) $ Var () xs'
           , Var () x
           ]
 
@@ -148,15 +149,15 @@ getBuiltinFoldList = do
         . TyAbs () a (Type ())
         . TyAbs () r (Type ())
         . LamAbs () f (TyFun () (TyVar () r) . TyFun () (TyVar () a) $ TyVar () r)
-        . Apply () (foldl' (TyInst ()) fix [TyVar () r, TyFun () listA $ TyVar () r])
+        . Apply () (mkIterInst fix [TyVar () r, TyFun () listA $ TyVar () r])
         . LamAbs () rec (TyFun () (TyVar () r) . TyFun () listA $ TyVar () r)
         . LamAbs () z (TyVar () r)
         . LamAbs () xs listA
         . Apply () (Apply () (TyInst () (Unwrap () (Var () xs)) $ TyVar () r) $ Var () z)
         . LamAbs () x (TyVar () a)
         . Apply () (Var () rec)
-        . foldl' (Apply ()) (Var () f)
-        $ [ Var () z
+        $ mkIterApp (Var () f)
+          [ Var () z
           , Var () x
           ]
 
@@ -170,7 +171,7 @@ getBuiltinSum s = do
     foldList <- getBuiltinFoldList
     let int = TyBuiltin () TyInteger
     return
-        . foldl' (Apply ()) (foldl' (TyInst ()) foldList [int, int])
+        . mkIterApp (mkIterInst foldList [int, int])
         $ [ TyInst () (Constant () (BuiltinName () AddInteger)) $ TyInt () s
           , Constant () $ BuiltinInt () s 0
           ]

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Nat.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Nat.hs
@@ -9,6 +9,7 @@ module Language.PlutusCore.StdLib.Data.Nat
     , getBuiltinFoldNat
     ) where
 
+import           Language.PlutusCore.MkPlc
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Quote
 import           Language.PlutusCore.StdLib.Data.Function
@@ -91,7 +92,7 @@ getBuiltinFoldrNat = do
         . TyAbs () r (Type ())
         . LamAbs () f (TyFun () (TyVar () r) (TyVar () r))
         . LamAbs () z (TyVar () r)
-        . Apply () (foldl' (TyInst ()) fix [nat, TyVar () r])
+        . Apply () (mkIterInst fix [nat, TyVar () r])
         . LamAbs () rec (TyFun () nat $ TyVar () r)
         . LamAbs () n nat
         . Apply () (Apply () (TyInst () (Unwrap () (Var () n)) $ TyVar () r) $ Var () z)
@@ -120,7 +121,7 @@ getBuiltinFoldNat = do
     return
         . TyAbs () r (Type ())
         . LamAbs () f (TyFun () (TyVar () r) (TyVar () r))
-        . Apply () (foldl' (TyInst ()) fix [TyVar () r, TyFun () nat $ TyVar () r])
+        . Apply () (mkIterInst fix [TyVar () r, TyFun () nat $ TyVar () r])
         . LamAbs () rec (TyFun () (TyVar () r) . TyFun () nat $ TyVar () r)
         . LamAbs () z (TyVar () r)
         . LamAbs () n nat


### PR DESCRIPTION
We do a lot of similar kinds of task when constructing Plutus Core programs that can easily be abstracted out.

This PR introduced term construction functions for:
- Various kinds of iterated application and abstraction. I find these much easier than remembering the arguments to `foldl` and `foldr` every time.
- Making "lets" using lambdas and type abstractions.

The latter also comes with a `Quote` version that I hope will make our lives easier with having to define multiple copies of things to make sure we have global uniqueness. Instead we can just let-bind the damn thing and reference it as a variable. This has the advantage of reducing code size too!

I used this on the examples in `Bool`, but I stalled a bit on the recursive type case (which would also benefit from it). The problem is that in order to typecheck `wrap`s, we need to be able to see the recursive type as a `fix`, and not as an opaque type variable inside an application. And to "match" on it, we need to be able to see the shape of the pattern functor. So we need to bind the recursive type and its constructors/destructors "together" somehow, which I haven't figured out a nice way to do.

I plan to use this pattern more in the core-to-plc plugin in the future, so hopefully I'll come up with a way around these issues.